### PR TITLE
feat: auto-clear peer pencil notes (compound undo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Completion time tracking: play clock accumulates active time per game, pauses in the background and freezes on victory; terminal-style `T+MM:SS` timer in the game header (toggleable via the game menu), duration shown on victory, in archive rows, and in personal bests (#4)
+- Auto-clear pencil notes: placing a number removes that digit from notes in the same row, column, and box; undo/redo treats the placement and cleared notes as one compound move (#5)
 
 - `SudoSodokuTests` unit test target covering puzzle generation (solvability, unique solution, difficulty scoring), ELO rating (K-factor tiers, anti-smurfing), and storage (persistence roundtrip, legacy save migration)
 - Shared `SudoSodoku` scheme with test action, enabling `xcodebuild test` and Xcode Cloud test workflows

--- a/SudoSodoku/Models/MoveHistory.swift
+++ b/SudoSodoku/Models/MoveHistory.swift
@@ -1,9 +1,22 @@
 import Foundation
 
-struct MoveHistory {
+struct CellChange {
     let index: Int
     let oldCell: SudokuCell
     let newCell: SudokuCell
 }
 
+/// One undoable move. A single player action can touch several cells
+/// (placing a number also clears that digit from peer notes), so a move
+/// is a list of cell changes applied and reverted together.
+struct MoveHistory {
+    let changes: [CellChange]
 
+    init(changes: [CellChange]) {
+        self.changes = changes
+    }
+
+    init(index: Int, oldCell: SudokuCell, newCell: SudokuCell) {
+        self.changes = [CellChange(index: index, oldCell: oldCell, newCell: newCell)]
+    }
+}

--- a/SudoSodoku/ViewModels/SudokuGame.swift
+++ b/SudoSodoku/ViewModels/SudokuGame.swift
@@ -140,6 +140,7 @@ class SudokuGame: ObservableObject {
         guard let index = selectedCellIndex, !board[index].isGiven else { return }
 
         let oldCell = board[index]
+        var peerChanges: [CellChange] = []
 
         if isNoteMode {
             if board[index].notes.contains(number) {
@@ -153,24 +154,58 @@ class SudokuGame: ObservableObject {
             } else {
                 board[index].value = number
                 board[index].notes = []
+                peerChanges = clearPeerNotes(of: number, around: index)
             }
             updateBoardErrors()
             checkVictory()
         }
 
         let newCell = board[index]
+        var changes = peerChanges
         if oldCell != newCell {
-            undoStack.append(MoveHistory(index: index, oldCell: oldCell, newCell: newCell))
+            changes.insert(CellChange(index: index, oldCell: oldCell, newCell: newCell), at: 0)
+        }
+        if !changes.isEmpty {
+            undoStack.append(MoveHistory(changes: changes))
             redoStack.removeAll()
         }
 
         saveCurrentState()
     }
 
+    /// Placing a number removes it from the pencil notes of every peer
+    /// (same row, column, or box). Returns the changes for undo history.
+    private func clearPeerNotes(of number: Int, around index: Int) -> [CellChange] {
+        var changes: [CellChange] = []
+        for peer in peerIndices(of: index)
+        where board[peer].value == nil && board[peer].notes.contains(number) {
+            let oldCell = board[peer]
+            board[peer].notes.remove(number)
+            changes.append(CellChange(index: peer, oldCell: oldCell, newCell: board[peer]))
+        }
+        return changes
+    }
+
+    private func peerIndices(of index: Int) -> [Int] {
+        let row = index / 9
+        let col = index % 9
+        var peers = Set<Int>()
+        for i in 0..<9 {
+            peers.insert(row * 9 + i)
+            peers.insert(i * 9 + col)
+            let boxIndex = ((row / 3) * 3 + i / 3) * 9 + (col / 3) * 3 + i % 3
+            peers.insert(boxIndex)
+        }
+        peers.remove(index)
+        return Array(peers)
+    }
+
     func undoLastMove() {
         guard let lastMove = undoStack.popLast() else { return }
         redoStack.append(lastMove)
-        board[lastMove.index] = lastMove.oldCell
+        for change in lastMove.changes {
+            board[change.index] = change.oldCell
+        }
         updateBoardErrors()
         currentUndoCount += 1
         saveCurrentState()
@@ -180,7 +215,9 @@ class SudokuGame: ObservableObject {
     func redoLastMove() {
         guard let nextMove = redoStack.popLast() else { return }
         undoStack.append(nextMove)
-        board[nextMove.index] = nextMove.newCell
+        for change in nextMove.changes {
+            board[change.index] = change.newCell
+        }
         updateBoardErrors()
         saveCurrentState()
         HapticManager.shared.lightImpact()

--- a/SudoSodokuTests/AutoClearNotesTests.swift
+++ b/SudoSodokuTests/AutoClearNotesTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import SudoSodoku
+
+final class AutoClearNotesTests: XCTestCase {
+
+    private var fixtureIDs: [UUID] = []
+
+    override func tearDown() {
+        for id in fixtureIDs {
+            StorageManager.shared.deleteRecord(id: id)
+        }
+        fixtureIDs = []
+        super.tearDown()
+    }
+
+    // MARK: - Auto-clear on placement
+
+    func testPlacingNumberClearsItFromPeerNotes() {
+        let game = makeGame(notes: [
+            1: [5, 3],   // same row as cell 0
+            9: [5],      // same column
+            10: [5],     // same box
+            80: [5],     // unrelated cell
+        ])
+
+        game.selectCell(at: 0)
+        game.inputNumber(5)
+
+        XCTAssertEqual(game.board[0].value, 5)
+        XCTAssertEqual(game.board[1].notes, [3], "Peer in the same row must lose only the placed digit")
+        XCTAssertTrue(game.board[9].notes.isEmpty, "Peer in the same column must lose the digit")
+        XCTAssertTrue(game.board[10].notes.isEmpty, "Peer in the same box must lose the digit")
+        XCTAssertEqual(game.board[80].notes, [5], "Unrelated cells must keep their notes")
+    }
+
+    func testTogglingNumberOffDoesNotTouchPeerNotes() {
+        let game = makeGame(notes: [1: [5]])
+        game.selectCell(at: 0)
+        game.inputNumber(5)      // place
+        XCTAssertTrue(game.board[1].notes.isEmpty)
+
+        game.inputNumber(5)      // toggle off
+        XCTAssertNil(game.board[0].value)
+        XCTAssertTrue(game.board[1].notes.isEmpty, "Removing a value cannot resurrect peer notes")
+    }
+
+    func testNoteModeInputDoesNotClearPeerNotes() {
+        let game = makeGame(notes: [1: [5]])
+        game.isNoteMode = true
+        game.selectCell(at: 0)
+        game.inputNumber(5)
+
+        XCTAssertEqual(game.board[0].notes, [5])
+        XCTAssertEqual(game.board[1].notes, [5], "Pencil input must not clear peers")
+    }
+
+    // MARK: - Compound undo/redo
+
+    func testUndoRestoresValueAndAllPeerNotes() {
+        let game = makeGame(notes: [1: [5, 3], 9: [5], 10: [5]])
+        game.selectCell(at: 0)
+        game.inputNumber(5)
+
+        game.undoLastMove()
+
+        XCTAssertNil(game.board[0].value, "Undo must remove the placed value")
+        XCTAssertEqual(game.board[1].notes, [5, 3], "Undo must restore every cleared peer note")
+        XCTAssertEqual(game.board[9].notes, [5])
+        XCTAssertEqual(game.board[10].notes, [5])
+        XCTAssertTrue(game.undoStack.isEmpty)
+        XCTAssertEqual(game.redoStack.count, 1)
+    }
+
+    func testRedoReappliesValueAndPeerNoteClearing() {
+        let game = makeGame(notes: [1: [5, 3], 9: [5]])
+        game.selectCell(at: 0)
+        game.inputNumber(5)
+        game.undoLastMove()
+
+        game.redoLastMove()
+
+        XCTAssertEqual(game.board[0].value, 5)
+        XCTAssertEqual(game.board[1].notes, [3])
+        XCTAssertTrue(game.board[9].notes.isEmpty)
+        XCTAssertEqual(game.undoStack.count, 1)
+        XCTAssertTrue(game.redoStack.isEmpty)
+    }
+
+    func testPlacementIntoNoteFreeBoardRecordsSingleChange() {
+        let game = makeGame(notes: [:])
+        game.selectCell(at: 0)
+        game.inputNumber(5)
+
+        XCTAssertEqual(game.undoStack.count, 1)
+        XCTAssertEqual(game.undoStack[0].changes.count, 1, "No peer notes -> single-cell move")
+    }
+
+    // MARK: - Fixtures
+
+    /// Board loaded from an almost-empty record so no victory can trigger.
+    private func makeGame(notes: [Int: [Int]]) -> SudokuGame {
+        let solution = (0..<81).map { index -> Int in
+            let row = index / 9
+            let col = index % 9
+            return (row * 3 + row / 3 + col) % 9 + 1
+        }
+        var playerNotes: [[Int]] = Array(repeating: [], count: 81)
+        for (index, values) in notes {
+            playerNotes[index] = values
+        }
+
+        let record = GameRecord(
+            id: UUID(),
+            startTime: Date(),
+            lastPlayedTime: Date(),
+            difficulty: "EASY",
+            difficultyIndex: 10,
+            initialBoard: Array(repeating: 0, count: 81),
+            solution: solution,
+            playerBoard: Array(repeating: 0, count: 81),
+            playerNotes: playerNotes,
+            isSolved: false,
+            ratingChange: nil
+        )
+        fixtureIDs.append(record.id)
+
+        let game = SudokuGame()
+        game.loadFromRecord(record)
+        return game
+    }
+}


### PR DESCRIPTION
## Summary

Standard sudoku QoL that was missing: placing a number now clears that digit from pencil notes in the same row, column, and box.

- `MoveHistory` upgraded from a single-cell snapshot to a compound move (`[CellChange]`) — one undo restores the placed value **and** every cleared peer note together; redo reapplies them together. Existing single-cell call sites keep working via a convenience init
- Clearing happens only when actually placing a value: toggling a value off and pencil-mode input never touch peers

> **Stacked on #23** — this branch is based on `feature/time-tracking-issue-4`; merge #23 first and this PR will retarget to `main` automatically.

## Test plan

- [x] 6 new unit tests (`AutoClearNotesTests`): row/col/box peers cleared while unrelated cells keep notes, toggle-off leaves peers alone, pencil mode leaves peers alone, compound undo/redo, single-change history on note-free boards
- [x] Full suite: 30/30 passed on iPhone 17 Pro simulator

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)