### PR TITLE
fix: pin deployment target to 17.0 (Xcode Cloud availability errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Landing page version reads from app bundle instead of hardcoded string
 - Fixed swapped section bodies in DEVELOPER.md (Achievement System / iPad Support) and aligned the roadmap tiers with the phased v1.1-v1.3 plan
 
+### Fixed
+
+- Pinned `IPHONEOS_DEPLOYMENT_TARGET` back to the literal `17.0` on all targets: Xcode's "Update to recommended settings" had rewritten it to `$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)`, which Xcode Cloud's toolchain resolves to nothing, dropping the deployment target to the SDK floor and failing builds with iOS 16/17 availability errors
+
 ### Removed
 
 - `Views-iPad/` directory and `ViewRouter` platform routing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@
 
 - iPhone-only iOS app (`TARGETED_DEVICE_FAMILY = 1`), iOS 17.0+, SwiftUI + MVVM,
   Swift 5.9. **No iPadOS or macOS work** — deferred indefinitely.
+- `IPHONEOS_DEPLOYMENT_TARGET` must stay the literal `17.0` in project.pbxproj.
+  Do not accept Xcode's "Update to recommended settings" suggestion that rewrites
+  it to `$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)` — Xcode Cloud resolves that
+  macro to nothing and builds fail with iOS 16/17 availability errors.
 - Bundle ID `dev.kaichen.sudoku.app`; Game Center leaderboard IDs live in
   `SudoSodoku/Utils/AppConstants.swift`.
 - Persistence is a single local JSON file managed by `StorageManager`

--- a/SudoSodoku.xcodeproj/project.pbxproj
+++ b/SudoSodoku.xcodeproj/project.pbxproj
@@ -336,7 +336,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -375,7 +375,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -405,7 +405,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 4Q3P7THMVS;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.kaichen.sudoku.app.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -431,7 +431,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 4Q3P7THMVS;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = "$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.kaichen.sudoku.app.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Root cause

Xcode Cloud Build 8 failed Test/Archive with iOS 16/17 availability errors (`NavigationStack`, `navigationDestination(isPresented:)`, `onChange(of:initial:)`), even though the project targets iOS 17.0.

Xcode's **"Update to recommended settings"** prompt (the yellow ⚠️ badge) had rewritten `IPHONEOS_DEPLOYMENT_TARGET` on the app and test targets from the literal `17.0` to `$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)`. The local Xcode beta resolves that macro to 17.0, so local builds and tests kept passing — but Xcode Cloud's toolchain resolves it to nothing, the target-level setting overrides the project-level `17.0`, and the effective deployment target drops to the SDK floor. Every iOS 16/17 API then fails availability checking.

## Fix

- Pin all four target-level configs back to the literal `17.0` (project-level was already literal)
- CLAUDE.md note so future sessions don't re-accept the recommended-settings rewrite

## Test plan

- [x] `plutil -lint` OK; 6/6 deployment-target entries now literal `17.0`
- [x] Release build for `generic/platform=iOS` (archive compile path): clean
- [x] Full unit test suite: 17/17 passed

After merge: hit **Rebuild** in Xcode Cloud — both Test - iOS and Archive - iOS should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)