### PR TITLE
feat: numpad exhaustion strike-out + no-selection affordance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Completion time tracking: play clock accumulates active time per game, pauses in the background and freezes on victory; terminal-style `T+MM:SS` timer in the game header (toggleable via the game menu), duration shown on victory, in archive rows, and in personal bests (#4)
 - Auto-clear pencil notes: placing a number removes that digit from notes in the same row, column, and box; undo/redo treats the placement and cleared notes as one compound move (#5)
-
+- Numpad digit keys dim and strike through once all nine instances of a digit are placed; undo/clear revives them (#6)
+- Numpad dims when no cell is selected and taps give a warning haptic nudge instead of being silently swallowed (#7)
 - `SudoSodokuTests` unit test target covering puzzle generation (solvability, unique solution, difficulty scoring), ELO rating (K-factor tiers, anti-smurfing), and storage (persistence roundtrip, legacy save migration)
 - Shared `SudoSodoku` scheme with test action, enabling `xcodebuild test` and Xcode Cloud test workflows
 

--- a/SudoSodoku/Managers/HapticManager.swift
+++ b/SudoSodoku/Managers/HapticManager.swift
@@ -10,4 +10,8 @@ class HapticManager {
     func success() {
         UINotificationFeedbackGenerator().notificationOccurred(.success)
     }
+
+    func warning() {
+        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+    }
 }

--- a/SudoSodoku/ViewModels/SudokuGame.swift
+++ b/SudoSodoku/ViewModels/SudokuGame.swift
@@ -200,6 +200,18 @@ class SudokuGame: ObservableObject {
         return Array(peers)
     }
 
+    // MARK: - Digit availability
+
+    func placedCount(of number: Int) -> Int {
+        board.filter { $0.value == number }.count
+    }
+
+    /// A digit is exhausted once all nine instances are on the board.
+    /// Derived from board state, so undo/clear revives the numpad key.
+    func isExhausted(_ number: Int) -> Bool {
+        placedCount(of: number) >= 9
+    }
+
     func undoLastMove() {
         guard let lastMove = undoStack.popLast() else { return }
         redoStack.append(lastMove)

--- a/SudoSodoku/Views/ControlPanelView.swift
+++ b/SudoSodoku/Views/ControlPanelView.swift
@@ -65,21 +65,34 @@ struct ControlPanelView: View {
             .padding(.horizontal, 20)
             
             // 3. Numpad
+            let hasSelection = game.selectedCellIndex != nil
             LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 9), spacing: 8) {
                 ForEach(1...9, id: \.self) { num in
-                    Button(action: { game.inputNumber(num) }) {
+                    let exhausted = game.isExhausted(num)
+                    Button(action: {
+                        // With no cell selected the input would be silently
+                        // swallowed; nudge instead so the tap never feels dead.
+                        guard hasSelection else {
+                            HapticManager.shared.warning()
+                            return
+                        }
+                        game.inputNumber(num)
+                    }) {
                         Text("\(num)")
                             .font(.system(size: 24, weight: .bold, design: .monospaced))
+                            .strikethrough(exhausted, color: .gray)
                             .frame(maxWidth: .infinity)
                             .frame(height: 55)
-                            .background(Color.white.opacity(0.1))
-                            .foregroundColor(.white)
+                            .background(Color.white.opacity(exhausted ? 0.04 : 0.1))
+                            .foregroundColor(exhausted ? .gray.opacity(0.5) : .white)
                             .cornerRadius(12)
                     }
                     .buttonStyle(BouncyButtonStyle())
                 }
             }
             .padding(.horizontal)
+            .opacity(hasSelection ? 1.0 : 0.45)
+            .animation(.easeInOut(duration: 0.15), value: hasSelection)
         }
     }
 }

--- a/SudoSodokuTests/DigitAvailabilityTests.swift
+++ b/SudoSodokuTests/DigitAvailabilityTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import SudoSodoku
+
+final class DigitAvailabilityTests: XCTestCase {
+
+    private var fixtureIDs: [UUID] = []
+
+    override func tearDown() {
+        for id in fixtureIDs {
+            StorageManager.shared.deleteRecord(id: id)
+        }
+        fixtureIDs = []
+        super.tearDown()
+    }
+
+    func testPlacedCountIncludesGivensAndPlayerValues() {
+        // A given 5 at index 0 plus a player-placed 5 at index 9.
+        let game = makeGame(givens: [0: 5], playerValues: [9: 5])
+        XCTAssertEqual(game.placedCount(of: 5), 2)
+        XCTAssertEqual(game.placedCount(of: 3), 0)
+        XCTAssertFalse(game.isExhausted(5))
+    }
+
+    func testDigitBecomesExhaustedOnNinthPlacement() {
+        let game = makeGame(playerValues: eightFives())
+        XCTAssertFalse(game.isExhausted(5))
+
+        game.selectCell(at: 40)
+        game.inputNumber(5)
+
+        XCTAssertEqual(game.placedCount(of: 5), 9)
+        XCTAssertTrue(game.isExhausted(5))
+    }
+
+    func testUndoRevivesExhaustedDigit() {
+        let game = makeGame(playerValues: eightFives())
+        game.selectCell(at: 40)
+        game.inputNumber(5)
+        XCTAssertTrue(game.isExhausted(5))
+
+        game.undoLastMove()
+        XCTAssertFalse(game.isExhausted(5), "Undo must revive the numpad key")
+
+        game.redoLastMove()
+        XCTAssertTrue(game.isExhausted(5), "Redo must exhaust it again")
+    }
+
+    func testClearingCellRevivesExhaustedDigit() {
+        let game = makeGame(playerValues: eightFives())
+        game.selectCell(at: 40)
+        game.inputNumber(5)
+        XCTAssertTrue(game.isExhausted(5))
+
+        game.clearSelectedCell()
+        XCTAssertFalse(game.isExhausted(5), "Clearing a cell must revive the numpad key")
+    }
+
+    // MARK: - Fixtures
+
+    /// Eight player-placed 5s spread over the board, leaving index 40 free.
+    private func eightFives() -> [Int: Int] {
+        Dictionary(uniqueKeysWithValues: [0, 10, 20, 30, 41, 50, 60, 70].map { ($0, 5) })
+    }
+
+    private func makeGame(givens: [Int: Int] = [:], playerValues: [Int: Int] = [:]) -> SudokuGame {
+        var initial = Array(repeating: 0, count: 81)
+        for (index, value) in givens { initial[index] = value }
+        var player = Array(repeating: 0, count: 81)
+        for (index, value) in playerValues { player[index] = value }
+        let solution = (0..<81).map { index -> Int in
+            let row = index / 9
+            let col = index % 9
+            return (row * 3 + row / 3 + col) % 9 + 1
+        }
+
+        let record = GameRecord(
+            id: UUID(),
+            startTime: Date(),
+            lastPlayedTime: Date(),
+            difficulty: "EASY",
+            difficultyIndex: 10,
+            initialBoard: initial,
+            solution: solution,
+            playerBoard: player,
+            playerNotes: Array(repeating: [], count: 81),
+            isSolved: false,
+            ratingChange: nil
+        )
+        fixtureIDs.append(record.id)
+
+        let game = SudokuGame()
+        game.loadFromRecord(record)
+        return game
+    }
+}


### PR DESCRIPTION
## Summary

Two small ControlPanelView UX items from Tier A, shipped together:

**#6 — Digit exhaustion (strike-out)**
- New `SudokuGame.placedCount(of:)` / `isExhausted(_:)`, derived from board state — undo, redo, and clearing a cell all revive the key automatically
- Exhausted keys render dimmed with a strikethrough (terminal style), background fades; keys stay tappable so purists keep full control

**#7 — No-selection affordance**
- Tapping a digit with no cell selected was silently swallowed (`inputNumber` guard) and felt like a dead tap
- The numpad now dims to 45% opacity while nothing is selected (0.15s opacity fade — color-only, Reduce Motion safe), and taps fire a `.warning` haptic nudge via the new `HapticManager.warning()`

Also removes a stray blank line in CHANGELOG left over from the #23/#24 merge.

## Test plan

- [x] 4 new unit tests (`DigitAvailabilityTests`): counts include givens + player values, ninth placement exhausts, undo/redo revives/re-exhausts, clearing revives
- [x] Full suite: 34/34 passed on iPhone 17 Pro simulator

Closes #6
Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)