### PR TITLE
feat: haptic hierarchy + conflict shake + sliding selection (game feel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auto-clear pencil notes: placing a number removes that digit from notes in the same row, column, and box; undo/redo treats the placement and cleared notes as one compound move (#5)
 - Numpad digit keys dim and strike through once all nine instances of a digit are placed; undo/clear revives them (#6)
 - Numpad dims when no cell is selected and taps give a warning haptic nudge instead of being silently swallowed (#7)
+- Semantic haptic vocabulary: selection tick on cell changes (`.sensoryFeedback`), rigid impact on placement, soft impact on removal/notes, error notification on conflicts, and a custom CoreHaptics victory pattern (three ascending ticks + rumble) with graceful fallback (#8)
+- Conflicting placements shake the cell with a short CRT-glitch jitter alongside the error haptic; disabled under Reduce Motion (#9)
+- The selection frame is now a single shared rectangle that glides between cells with a spring instead of jumping; instant under Reduce Motion (#10)
 - `SudoSodokuTests` unit test target covering puzzle generation (solvability, unique solution, difficulty scoring), ELO rating (K-factor tiers, anti-smurfing), and storage (persistence roundtrip, legacy save migration)
 - Shared `SudoSodoku` scheme with test action, enabling `xcodebuild test` and Xcode Cloud test workflows
 

--- a/SudoSodoku/Managers/HapticManager.swift
+++ b/SudoSodoku/Managers/HapticManager.swift
@@ -1,17 +1,117 @@
+import CoreHaptics
 import UIKit
 
-class HapticManager {
+/// Semantic haptic vocabulary for the whole app. Views and the view model
+/// express intent (digitPlaced, conflictDetected, ...) and never touch
+/// concrete generators, so the game's feel is tuned in this one file.
+final class HapticManager {
     static let shared = HapticManager()
 
-    func lightImpact() {
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    private let selectionGenerator = UISelectionFeedbackGenerator()
+    private let lightGenerator = UIImpactFeedbackGenerator(style: .light)
+    private let rigidGenerator = UIImpactFeedbackGenerator(style: .rigid)
+    private let mediumGenerator = UIImpactFeedbackGenerator(style: .medium)
+    private let notificationGenerator = UINotificationFeedbackGenerator()
+    private var hapticEngine: CHHapticEngine?
+
+    // MARK: - Board interactions
+
+    /// Mechanical key press: a value snaps into a cell.
+    func digitPlaced() {
+        rigidGenerator.impactOccurred()
+    }
+
+    /// A value leaves the board (toggle-off or DEL).
+    func digitRemoved() {
+        lightGenerator.impactOccurred()
+    }
+
+    /// Pencil note toggled on/off — softer than a real placement.
+    func noteToggled() {
+        lightGenerator.impactOccurred(intensity: 0.6)
+    }
+
+    /// The placed digit conflicts with a peer.
+    func conflictDetected() {
+        notificationGenerator.notificationOccurred(.error)
+    }
+
+    /// A row, column, or box was just completed (reserved for #16).
+    func unitCompleted() {
+        mediumGenerator.impactOccurred()
+    }
+
+    // MARK: - Controls
+
+    /// Note mode switched — feels like a mode selector click.
+    func noteModeToggled() {
+        selectionGenerator.selectionChanged()
+    }
+
+    /// Undo or redo applied.
+    func moveReverted() {
+        lightGenerator.impactOccurred()
+    }
+
+    /// Input ignored (e.g. no cell selected) — nudge, not punish.
+    func warning() {
+        notificationGenerator.notificationOccurred(.warning)
     }
 
     func success() {
-        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        notificationGenerator.notificationOccurred(.success)
     }
 
-    func warning() {
-        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+    // MARK: - Victory
+
+    /// Three ascending ticks followed by a soft rumble. Falls back to the
+    /// plain success notification when custom haptics are unavailable
+    /// (simulator, older devices, engine failure).
+    func victory() {
+        guard CHHapticEngine.capabilitiesForHardware().supportsHaptics,
+              let engine = victoryEngine() else {
+            success()
+            return
+        }
+        do {
+            var events: [CHHapticEvent] = []
+            for (step, time) in [0.0, 0.1, 0.2].enumerated() {
+                events.append(CHHapticEvent(
+                    eventType: .hapticTransient,
+                    parameters: [
+                        CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.6 + Float(step) * 0.15),
+                        CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.6 + Float(step) * 0.1),
+                    ],
+                    relativeTime: time
+                ))
+            }
+            events.append(CHHapticEvent(
+                eventType: .hapticContinuous,
+                parameters: [
+                    CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.8),
+                    CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.25),
+                ],
+                relativeTime: 0.32,
+                duration: 0.45
+            ))
+            let pattern = try CHHapticPattern(events: events, parameters: [])
+            let player = try engine.makePlayer(with: pattern)
+            try player.start(atTime: CHHapticTimeImmediate)
+        } catch {
+            success()
+        }
+    }
+
+    private func victoryEngine() -> CHHapticEngine? {
+        if let hapticEngine { return hapticEngine }
+        guard let engine = try? CHHapticEngine() else { return nil }
+        engine.playsHapticsOnly = true
+        // The engine starts itself when a player starts and shuts down when idle.
+        engine.isAutoShutdownEnabled = true
+        engine.resetHandler = { [weak self] in
+            self?.hapticEngine = nil
+        }
+        hapticEngine = engine
+        return engine
     }
 }

--- a/SudoSodoku/ViewModels/SudokuGame.swift
+++ b/SudoSodoku/ViewModels/SudokuGame.swift
@@ -16,6 +16,11 @@ class SudokuGame: ObservableObject {
     @Published var undoStack: [MoveHistory] = []
     @Published var redoStack: [MoveHistory] = []
 
+    // Per-cell shake counters; a cell shakes each time its counter increments.
+    // Monotonically increasing on purpose: resetting to zero would itself be a
+    // change and replay stale shakes on fresh boards.
+    @Published private(set) var conflictShakes: [Int: Int] = [:]
+
     var onSolved: (() -> Void)?
     var currentRecordID: UUID?
 
@@ -148,15 +153,24 @@ class SudokuGame: ObservableObject {
             } else {
                 board[index].notes.insert(number)
             }
+            HapticManager.shared.noteToggled()
         } else {
             if board[index].value == number {
                 board[index].value = nil
+                updateBoardErrors()
+                HapticManager.shared.digitRemoved()
             } else {
                 board[index].value = number
                 board[index].notes = []
                 peerChanges = clearPeerNotes(of: number, around: index)
+                updateBoardErrors()
+                if board[index].isError {
+                    conflictShakes[index, default: 0] += 1
+                    HapticManager.shared.conflictDetected()
+                } else {
+                    HapticManager.shared.digitPlaced()
+                }
             }
-            updateBoardErrors()
             checkVictory()
         }
 
@@ -221,7 +235,7 @@ class SudokuGame: ObservableObject {
         updateBoardErrors()
         currentUndoCount += 1
         saveCurrentState()
-        HapticManager.shared.lightImpact()
+        HapticManager.shared.moveReverted()
     }
 
     func redoLastMove() {
@@ -232,7 +246,7 @@ class SudokuGame: ObservableObject {
         }
         updateBoardErrors()
         saveCurrentState()
-        HapticManager.shared.lightImpact()
+        HapticManager.shared.moveReverted()
     }
 
     func clearSelectedCell() {
@@ -247,6 +261,7 @@ class SudokuGame: ObservableObject {
         if oldCell != newCell {
             undoStack.append(MoveHistory(index: index, oldCell: oldCell, newCell: newCell))
             redoStack.removeAll()
+            HapticManager.shared.digitRemoved()
         }
 
         updateBoardErrors()
@@ -373,7 +388,7 @@ class SudokuGame: ObservableObject {
 
         isSolved = true
         pauseClock()
-        HapticManager.shared.success()
+        HapticManager.shared.victory()
 
         let currentElo = StorageManager.shared.userRating
         let gained = RatingManager.shared.calculateRatingChange(

--- a/SudoSodoku/Views/BoardView.swift
+++ b/SudoSodoku/Views/BoardView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct BoardView: View {
     @ObservedObject var game: SudokuGame
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         GeometryReader { geometry in
@@ -18,15 +19,41 @@ struct BoardView: View {
                             isSelected: game.selectedCellIndex == index,
                             isRelated: isRelated(index: index),
                             highlightNumber: getHighlightNumber(),
+                            shakeTrigger: game.conflictShakes[index] ?? 0,
                             onTap: { game.selectCell(at: index) }
                         )
                     }
                 }
                 .overlay(GridLinesOverlay(width: width))
+                .overlay(selectionFrame(cellSize: cellSize))
                 .border(Color.gray, width: 2)
+                .sensoryFeedback(.selection, trigger: game.selectedCellIndex)
             }
         }
         .aspectRatio(1, contentMode: .fit)
+    }
+
+    /// One shared selection rectangle that glides between cells instead of
+    /// jumping (per-cell strokes can only appear/disappear). Instant under
+    /// Reduce Motion.
+    @ViewBuilder
+    private func selectionFrame(cellSize: CGFloat) -> some View {
+        Group {
+            if let index = game.selectedCellIndex {
+                Rectangle()
+                    .stroke(Color.green, lineWidth: 2)
+                    .frame(width: cellSize, height: cellSize)
+                    .position(
+                        x: (CGFloat(index % 9) + 0.5) * cellSize,
+                        y: (CGFloat(index / 9) + 0.5) * cellSize
+                    )
+            }
+        }
+        .allowsHitTesting(false)
+        .animation(
+            reduceMotion ? nil : .spring(response: 0.2, dampingFraction: 0.8),
+            value: game.selectedCellIndex
+        )
     }
 
     private func isRelated(index: Int) -> Bool {

--- a/SudoSodoku/Views/Components/CellView.swift
+++ b/SudoSodoku/Views/Components/CellView.swift
@@ -6,14 +6,17 @@ struct CellView: View {
     let isSelected: Bool
     let isRelated: Bool
     let highlightNumber: Int?
+    /// Increments each time this cell receives a conflicting digit (see
+    /// SudokuGame.conflictShakes); every increment plays one shake.
+    let shakeTrigger: Int
     var onTap: () -> Void
 
     @State private var animateTrigger = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         ZStack {
             Rectangle().fill(bg).border(Color.white.opacity(0.1), width: 0.5)
-            if isSelected { Rectangle().stroke(Color.green, lineWidth: 2).zIndex(10) }
 
             if cell.value == nil && !cell.notes.isEmpty {
                 NoteGridView(notes: cell.notes, size: cellSize)
@@ -28,13 +31,25 @@ struct CellView: View {
         .frame(width: cellSize, height: cellSize)
         .contentShape(Rectangle())
         .scaleEffect(animateTrigger ? 0.92 : 1.0)
+        .keyframeAnimator(initialValue: 0.0, trigger: shakeTrigger) { content, offset in
+            content.offset(x: offset)
+        } keyframes: { _ in
+            // CRT-glitch jitter on conflict; collapses to a no-op (amplitude 0)
+            // when Reduce Motion is on — the red text still marks the error.
+            let amplitude: Double = reduceMotion ? 0 : cellSize * 0.08
+            LinearKeyframe(-amplitude, duration: 0.05)
+            LinearKeyframe(amplitude, duration: 0.05)
+            LinearKeyframe(-amplitude * 0.5, duration: 0.05)
+            LinearKeyframe(0.0, duration: 0.05)
+        }
         .onTapGesture {
-            HapticManager.shared.lightImpact()
-            withAnimation(.spring(response: 0.2, dampingFraction: 0.5)) { animateTrigger = true }
-            onTap()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                withAnimation(.spring(response: 0.2, dampingFraction: 0.5)) { animateTrigger = false }
+            if !reduceMotion {
+                withAnimation(.spring(response: 0.2, dampingFraction: 0.5)) { animateTrigger = true }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    withAnimation(.spring(response: 0.2, dampingFraction: 0.5)) { animateTrigger = false }
+                }
             }
+            onTap()
         }
     }
 

--- a/SudoSodoku/Views/ControlPanelView.swift
+++ b/SudoSodoku/Views/ControlPanelView.swift
@@ -39,7 +39,7 @@ struct ControlPanelView: View {
             HStack {
                 Button(action: {
                     game.isNoteMode.toggle()
-                    HapticManager.shared.lightImpact()
+                    HapticManager.shared.noteModeToggled()
                 }) {
                     VStack {
                         Image(systemName: game.isNoteMode ? "pencil.circle.fill" : "pencil.circle")

--- a/SudoSodoku/Views/Styles/BouncyButtonStyle.swift
+++ b/SudoSodoku/Views/Styles/BouncyButtonStyle.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
+// Pure press animation; haptics come from the semantic vocabulary in
+// HapticManager (placement, note toggle, warning) so key presses don't
+// double-fire with the action's own feedback.
 struct BouncyButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .scaleEffect(configuration.isPressed ? 0.9 : 1.0)
             .animation(.spring(response: 0.3, dampingFraction: 0.6), value: configuration.isPressed)
-            .onChange(of: configuration.isPressed) { _, pressed in
-                if pressed { HapticManager.shared.lightImpact() }
-            }
     }
 }
 

--- a/SudoSodokuTests/ConflictFeedbackTests.swift
+++ b/SudoSodokuTests/ConflictFeedbackTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import SudoSodoku
+
+final class ConflictFeedbackTests: XCTestCase {
+
+    private var fixtureIDs: [UUID] = []
+
+    override func tearDown() {
+        for id in fixtureIDs {
+            StorageManager.shared.deleteRecord(id: id)
+        }
+        fixtureIDs = []
+        super.tearDown()
+    }
+
+    func testConflictingPlacementIncrementsShakeCounter() {
+        // Given 5 at index 1 (row 0); placing 5 at index 0 conflicts.
+        let game = makeGame(givens: [1: 5])
+
+        game.selectCell(at: 0)
+        game.inputNumber(5)
+
+        XCTAssertTrue(game.board[0].isError)
+        XCTAssertEqual(game.conflictShakes[0], 1)
+    }
+
+    func testValidPlacementDoesNotShake() {
+        let game = makeGame(givens: [1: 5])
+
+        game.selectCell(at: 0)
+        game.inputNumber(3)
+
+        XCTAssertFalse(game.board[0].isError)
+        XCTAssertNil(game.conflictShakes[0], "Valid placements must not register a shake")
+    }
+
+    func testRepeatedConflictShakesAgain() {
+        let game = makeGame(givens: [1: 5])
+        game.selectCell(at: 0)
+
+        game.inputNumber(5)              // conflict #1
+        game.inputNumber(5)              // toggle the value off
+        XCTAssertEqual(game.conflictShakes[0], 1, "Removing the value must not shake")
+
+        game.inputNumber(5)              // conflict #2
+        XCTAssertEqual(game.conflictShakes[0], 2, "Each fresh conflict must shake again")
+    }
+
+    func testUndoDoesNotShake() {
+        let game = makeGame(givens: [1: 5])
+        game.selectCell(at: 0)
+        game.inputNumber(5)
+        XCTAssertEqual(game.conflictShakes[0], 1)
+
+        game.undoLastMove()
+        XCTAssertEqual(game.conflictShakes[0], 1, "Undo reverts the board silently")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeGame(givens: [Int: Int]) -> SudokuGame {
+        var initial = Array(repeating: 0, count: 81)
+        for (index, value) in givens { initial[index] = value }
+        let solution = (0..<81).map { index -> Int in
+            let row = index / 9
+            let col = index % 9
+            return (row * 3 + row / 3 + col) % 9 + 1
+        }
+
+        let record = GameRecord(
+            id: UUID(),
+            startTime: Date(),
+            lastPlayedTime: Date(),
+            difficulty: "EASY",
+            difficultyIndex: 10,
+            initialBoard: initial,
+            solution: solution,
+            playerBoard: Array(repeating: 0, count: 81),
+            playerNotes: Array(repeating: [], count: 81),
+            isSolved: false,
+            ratingChange: nil
+        )
+        fixtureIDs.append(record.id)
+
+        let game = SudokuGame()
+        game.loadFromRecord(record)
+        return game
+    }
+}


### PR DESCRIPTION
## Summary

The remaining three Tier A game-feel items, shipped together (they share files):

**#8 — Haptic hierarchy**
- `HapticManager` rewritten as a semantic vocabulary — call sites express intent, never generators: `digitPlaced` (rigid), `digitRemoved` (light), `noteToggled` (soft light), `conflictDetected` (.error), `noteModeToggled` (selection tick), `moveReverted` (light), `unitCompleted` (medium, reserved for #16), `warning`, `victory`
- Victory is a custom CoreHaptics pattern: three ascending transient ticks + a 0.45s rumble, with `isAutoShutdownEnabled` engine management and graceful fallback to the plain success notification (simulator / unsupported hardware / engine failure)
- Cell-selection feedback is declarative: `.sensoryFeedback(.selection, trigger: selectedCellIndex)` on the board — fires only on actual selection *changes*, so re-tapping the same cell no longer buzzes
- `BouncyButtonStyle` no longer fires its own haptic (it double-fired with the action's semantic feedback)

**#9 — Conflict shake**
- Placing a conflicting digit shakes the cell (CRT-glitch jitter, ~0.2s, `keyframeAnimator`) plus the `.error` haptic
- Driven by per-cell monotonically increasing counters (`SudokuGame.conflictShakes`) — counters never reset so stale shakes can't replay on fresh boards; amplitude collapses to 0 under Reduce Motion (red text still marks the error)

**#10 — Sliding selection frame**
- One shared green rectangle glides between cells with a spring (`position` animation at board level) instead of per-cell strokes that can only appear/disappear; instant under Reduce Motion, hit-testing disabled

**Extras (small, in the same spirit)**
- DEL / clear now gives `digitRemoved` feedback (was silent)
- The pre-existing cell tap bounce now respects Reduce Motion (CLAUDE.md accessibility baseline; it previously always animated)

> **Stacked on #26** — merge #26 first; this PR retargets to `main` automatically.

## Test plan

- [x] 4 new unit tests (`ConflictFeedbackTests`): conflict increments the shake counter, valid placement doesn't, repeated conflicts shake again while toggle-off doesn't, undo reverts silently
- [x] Full suite: 38/38 passed on iPhone 17 Pro simulator
- [ ] On-device feel pass (haptics don't run in the simulator — worth 2 minutes on your iPhone after merge)

Closes #8
Closes #9
Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)