### PR TITLE
feat: Game Center leaderboards (ELO + fastest-time boards)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Semantic haptic vocabulary: selection tick on cell changes (`.sensoryFeedback`), rigid impact on placement, soft impact on removal/notes, error notification on conflicts, and a custom CoreHaptics victory pattern (three ascending ticks + rumble) with graceful fallback (#8)
 - Conflicting placements shake the cell with a short CRT-glitch jitter alongside the error haptic; disabled under Reduce Motion (#9)
 - The selection frame is now a single shared rectangle that glides between cells with a spring instead of jumping; instant under Reduce Motion (#10)
+- Game Center leaderboards: global ELO ranking plus per-difficulty fastest-time boards; victories submit the solve time (whole seconds) and rating gains submit the new ELO; terminal-styled leaderboard screen (`cat /leaderboard` in the profile) with guest sign-in notice and `GKAccessPoint` fallback (#11)
 - `SudoSodokuTests` unit test target covering puzzle generation (solvability, unique solution, difficulty scoring), ELO rating (K-factor tiers, anti-smurfing), and storage (persistence roundtrip, legacy save migration)
 - Shared `SudoSodoku` scheme with test action, enabling `xcodebuild test` and Xcode Cloud test workflows
 
 ### Changed
 
+- Leaderboard submissions previously sent the puzzle difficulty index (0-100), which ranked players by generation luck; scores are now actual performance — solve time per difficulty, ELO on the global board (#11)
 - Set minimum deployment target to iOS 17.0 (aligned project and target settings)
 - iPhone-only app: removed iPad-specific views, routing, and orientation settings
 - Updated documentation to reflect local-only persistence (no iCloud sync)

--- a/SudoSodoku/Managers/GameCenterManager.swift
+++ b/SudoSodoku/Managers/GameCenterManager.swift
@@ -47,9 +47,9 @@ class GameCenterManager: NSObject, ObservableObject {
         }
     }
 
-    /// Submits the player's current ELO to the global ranking. Game Center
-    /// keeps the highest submitted value; ELO only rises in this game, so the
-    /// board always reflects the latest rating.
+    /// Submits the player's current ELO to the global ranking. The board is
+    /// configured as "Most Recent Score" in ASC, so it always shows the
+    /// current rating — correct even if ratings can drop in the future.
     func submitRating(_ rating: Int) {
         guard isAuthenticated else { return }
 
@@ -62,7 +62,8 @@ class GameCenterManager: NSObject, ObservableObject {
     }
 
     /// Submits a solve time to the per-difficulty fastest-time board.
-    /// Game Center keeps the lowest submitted value automatically.
+    /// Boards are "Best Score" + Low-to-High in ASC, so Game Center keeps
+    /// only the fastest submission automatically.
     func submitCompletionTime(_ duration: TimeInterval, difficulty: String) {
         guard isAuthenticated else { return }
 

--- a/SudoSodoku/Managers/GameCenterManager.swift
+++ b/SudoSodoku/Managers/GameCenterManager.swift
@@ -47,15 +47,33 @@ class GameCenterManager: NSObject, ObservableObject {
         }
     }
 
-    func submitScore(_ score: Int, difficulty: String) {
+    /// Submits the player's current ELO to the global ranking. Game Center
+    /// keeps the highest submitted value; ELO only rises in this game, so the
+    /// board always reflects the latest rating.
+    func submitRating(_ rating: Int) {
         guard isAuthenticated else { return }
 
-        let leaderboardID = AppConstants.leaderboardID(for: difficulty)
         GKLeaderboard.submitScore(
-            score,
+            rating,
             context: 0,
             player: GKLocalPlayer.local,
-            leaderboardIDs: [leaderboardID]
+            leaderboardIDs: [AppConstants.eloLeaderboardID]
+        ) { _ in }
+    }
+
+    /// Submits a solve time to the per-difficulty fastest-time board.
+    /// Game Center keeps the lowest submitted value automatically.
+    func submitCompletionTime(_ duration: TimeInterval, difficulty: String) {
+        guard isAuthenticated else { return }
+
+        let value = AppConstants.timeLeaderboardValue(for: duration)
+        guard value > 0 else { return }
+
+        GKLeaderboard.submitScore(
+            value,
+            context: 0,
+            player: GKLocalPlayer.local,
+            leaderboardIDs: [AppConstants.leaderboardID(for: difficulty)]
         ) { _ in }
     }
 }

--- a/SudoSodoku/Utils/AppConstants.swift
+++ b/SudoSodoku/Utils/AppConstants.swift
@@ -4,6 +4,17 @@ enum AppConstants {
     static let bundleIdentifier = "dev.kaichen.sudoku.app"
     static let leaderboardPrefix = "dev.kaichen.sudoku.app.leaderboard"
 
+    /// Global ELO ranking (ASC format: Integer, best = highest).
+    static let eloLeaderboardID = "\(leaderboardPrefix).elo"
+
+    /// Per-difficulty boards are configured in ASC as "Elapsed Time — To the
+    /// Second" (best = lowest), so submitted values are whole seconds.
+    /// Returns 0 for non-positive durations, which callers must not submit —
+    /// a zero-second entry would otherwise own rank one forever.
+    static func timeLeaderboardValue(for duration: TimeInterval) -> Int {
+        duration <= 0 ? 0 : max(1, Int(duration.rounded()))
+    }
+
     static var marketingVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
     }

--- a/SudoSodoku/ViewModels/SudokuGame.swift
+++ b/SudoSodoku/ViewModels/SudokuGame.swift
@@ -399,9 +399,11 @@ class SudokuGame: ObservableObject {
 
         if gained > 0 {
             StorageManager.shared.updateUserRating(add: gained)
+            GameCenterManager.shared.submitRating(StorageManager.shared.userRating)
         }
 
-        GameCenterManager.shared.submitScore(currentScore, difficulty: difficulty.rawValue)
+        // Clock is already frozen, so this is the final solve time.
+        GameCenterManager.shared.submitCompletionTime(playDuration(), difficulty: difficulty.rawValue)
         saveCurrentState()
         onSolved?()
     }

--- a/SudoSodoku/Views/LeaderboardView.swift
+++ b/SudoSodoku/Views/LeaderboardView.swift
@@ -1,0 +1,205 @@
+import GameKit
+import SwiftUI
+
+struct LeaderboardView: View {
+    enum Board: String, CaseIterable, Identifiable {
+        case elo = "ELO"
+        case easy = "EASY"
+        case medium = "MEDIUM"
+        case hard = "HARD"
+        case master = "MASTER"
+
+        var id: String { rawValue }
+
+        var leaderboardID: String {
+            self == .elo
+                ? AppConstants.eloLeaderboardID
+                : AppConstants.leaderboardID(for: rawValue)
+        }
+    }
+
+    private enum LoadState {
+        case loading
+        case loaded(local: GKLeaderboard.Entry?, entries: [GKLeaderboard.Entry])
+        case failed(String)
+    }
+
+    @ObservedObject private var gcManager = GameCenterManager.shared
+    @State private var selectedBoard: Board = .elo
+    @State private var state: LoadState = .loading
+
+    var body: some View {
+        ZStack {
+            TerminalBackground()
+            VStack(alignment: .leading, spacing: 16) {
+                Text("GLOBAL_RANKINGS:")
+                    .font(.system(size: 16, weight: .bold, design: .monospaced))
+                    .foregroundColor(.gray)
+
+                boardPicker
+
+                if gcManager.isAuthenticated {
+                    content
+                } else {
+                    guestNotice
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .task(id: selectedBoard) { await load() }
+        .onChange(of: gcManager.isAuthenticated) { _, authenticated in
+            if authenticated { Task { await load() } }
+        }
+        // Native Game Center overlay as a fallback entry point while this
+        // screen is visible.
+        .onAppear {
+            GKAccessPoint.shared.location = .topTrailing
+            GKAccessPoint.shared.isActive = true
+        }
+        .onDisappear { GKAccessPoint.shared.isActive = false }
+    }
+
+    // MARK: - Sections
+
+    private var boardPicker: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(Board.allCases) { board in
+                    Button(action: { selectedBoard = board }) {
+                        Text(board.rawValue)
+                            .font(.system(size: 11, weight: .bold, design: .monospaced))
+                            .padding(.vertical, 6)
+                            .padding(.horizontal, 10)
+                            .background(selectedBoard == board ? Color.green.opacity(0.15) : Color.white.opacity(0.05))
+                            .foregroundColor(selectedBoard == board ? .green : .gray)
+                            .cornerRadius(6)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .stroke(selectedBoard == board ? Color.green : Color.clear, lineWidth: 1)
+                            )
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .loading:
+            VStack(alignment: .leading, spacing: 8) {
+                ProgressView().tint(.green)
+                Text("querying game center...")
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(.gray)
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.top, 40)
+
+        case .failed(let message):
+            VStack(alignment: .leading, spacing: 10) {
+                Text("ERR: \(message)")
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(.red)
+                Button(action: { Task { await load() } }) {
+                    Text("> RETRY")
+                        .font(.system(size: 14, weight: .bold, design: .monospaced))
+                        .foregroundColor(.green)
+                }
+            }
+            .padding(.top, 20)
+
+        case .loaded(let local, let entries):
+            if entries.isEmpty {
+                Text("NO_ENTRIES_YET // be the first to breach")
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(.gray)
+                    .padding(.top, 20)
+            } else {
+                ScrollView {
+                    VStack(spacing: 6) {
+                        ForEach(entries, id: \.rank) { entry in
+                            entryRow(entry, isLocalPlayer: isLocal(entry))
+                        }
+                    }
+                }
+                .refreshable { await load() }
+
+                if let local, !entries.contains(where: { isLocal($0) }) {
+                    Divider().background(Color.gray.opacity(0.3))
+                    entryRow(local, isLocalPlayer: true)
+                }
+            }
+        }
+    }
+
+    private var guestNotice: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("AUTH_REQUIRED")
+                .font(.system(size: 16, weight: .bold, design: .monospaced))
+                .foregroundColor(.yellow)
+            Text("sign in to Game Center to access global rankings\n(Settings > Games)")
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(.gray)
+        }
+        .padding(.top, 20)
+    }
+
+    private func entryRow(_ entry: GKLeaderboard.Entry, isLocalPlayer: Bool) -> some View {
+        HStack(spacing: 10) {
+            Text(String(format: "#%02d", entry.rank))
+                .font(.system(size: 13, weight: .bold, design: .monospaced))
+                .foregroundColor(rankColor(entry.rank))
+            Text(isLocalPlayer ? "\(entry.player.displayName) <you>" : entry.player.displayName)
+                .font(.system(size: 13, design: .monospaced))
+                .foregroundColor(isLocalPlayer ? .green : .white)
+                .lineLimit(1)
+            Spacer()
+            Text(entry.formattedScore)
+                .font(.system(size: 13, weight: .bold, design: .monospaced))
+                .foregroundColor(.green)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(isLocalPlayer ? Color.green.opacity(0.12) : Color.white.opacity(0.03))
+        .cornerRadius(8)
+    }
+
+    private func rankColor(_ rank: Int) -> Color {
+        switch rank {
+        case 1: return .yellow
+        case 2, 3: return .cyan
+        default: return .gray
+        }
+    }
+
+    private func isLocal(_ entry: GKLeaderboard.Entry) -> Bool {
+        entry.player.gamePlayerID == GKLocalPlayer.local.gamePlayerID
+    }
+
+    // MARK: - Loading
+
+    private func load() async {
+        guard gcManager.isAuthenticated else { return }
+        state = .loading
+        do {
+            guard let leaderboard = try await GKLeaderboard
+                .loadLeaderboards(IDs: [selectedBoard.leaderboardID]).first else {
+                state = .failed("leaderboard_not_configured")
+                return
+            }
+            let (local, entries, _) = try await leaderboard.loadEntries(
+                for: .global,
+                timeScope: .allTime,
+                range: NSRange(location: 1, length: 25)
+            )
+            state = .loaded(local: local, entries: entries)
+        } catch {
+            state = .failed(error.localizedDescription)
+        }
+    }
+}

--- a/SudoSodoku/Views/UserProfileView.swift
+++ b/SudoSodoku/Views/UserProfileView.swift
@@ -33,6 +33,21 @@ struct UserProfileView: View {
                         StatCard(title: "PUZZLES SOLVED", value: "\(stats.overallStats.solvedGames)", icon: "checkmark.seal")
                     }.padding(.horizontal)
 
+                    NavigationLink(destination: LeaderboardView()) {
+                        HStack {
+                            Image(systemName: "network")
+                            Text("cat /leaderboard")
+                        }
+                        .font(.system(size: 16, weight: .bold, design: .monospaced))
+                        .foregroundColor(.green)
+                        .padding(.vertical, 12)
+                        .frame(maxWidth: .infinity)
+                        .background(Color.green.opacity(0.1))
+                        .cornerRadius(12)
+                        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.green.opacity(0.5), lineWidth: 1))
+                    }
+                    .padding(.horizontal)
+
                     Spacer()
 
                     VStack(alignment: .leading, spacing: 15) {

--- a/SudoSodokuTests/LeaderboardConstantsTests.swift
+++ b/SudoSodokuTests/LeaderboardConstantsTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import SudoSodoku
+
+final class LeaderboardConstantsTests: XCTestCase {
+
+    func testLeaderboardIDsMatchAppStoreConnectConfiguration() {
+        XCTAssertEqual(AppConstants.eloLeaderboardID, "dev.kaichen.sudoku.app.leaderboard.elo")
+        XCTAssertEqual(AppConstants.leaderboardID(for: "EASY"), "dev.kaichen.sudoku.app.leaderboard.easy")
+        XCTAssertEqual(AppConstants.leaderboardID(for: "MASTER"), "dev.kaichen.sudoku.app.leaderboard.master")
+        XCTAssertEqual(
+            AppConstants.leaderboardID(for: "unknown"),
+            AppConstants.leaderboardPrefix,
+            "Unknown difficulties must fall back to the bare prefix"
+        )
+    }
+
+    func testTimeLeaderboardValueIsWholeSecondsAndGuarded() {
+        XCTAssertEqual(AppConstants.timeLeaderboardValue(for: 0), 0, "Zero duration must be rejected by callers")
+        XCTAssertEqual(AppConstants.timeLeaderboardValue(for: -5), 0, "Negative durations must map to the rejected value")
+        XCTAssertEqual(AppConstants.timeLeaderboardValue(for: 0.4), 1, "Sub-second solves round up to one second, never zero")
+        XCTAssertEqual(AppConstants.timeLeaderboardValue(for: 59.6), 60)
+        XCTAssertEqual(AppConstants.timeLeaderboardValue(for: 754.4), 754)
+    }
+}


### PR DESCRIPTION
## Summary

Code side of the Game Center leaderboards (week 2 headline):

**Submission semantics fixed**
- Old: `submitScore(currentScore)` sent the puzzle difficulty index (0-100) — rank #1 was whoever generated the hardest puzzle
- New: victory submits the frozen solve time (`playDuration()`, whole seconds) to the per-difficulty board; rating gains submit the updated ELO to the global board. Zero/legacy durations are guarded and never submitted (a 0s entry would own rank #1 forever). Revealed solutions (`showSolution`) never submit
- Game Center keeps best automatically: lowest for time boards, highest for the ELO board

**Terminal leaderboard UI** (`Views/LeaderboardView.swift`)
- Five tabs: ELO / EASY / MEDIUM / HARD / MASTER, top 25 via async `GKLeaderboard.loadEntries`
- Local player highlighted (`<you>`), with a footer row when outside the top 25; ranks #1-#3 tinted
- Guest state (`AUTH_REQUIRED`), error state with retry, pull-to-refresh, `GKAccessPoint` active as native fallback while the screen is visible
- Entry point: `cat /leaderboard` button in the profile
- Scores render via `entry.formattedScore`, so display always matches the ASC-configured format

## App Store Connect config required (Kai)

Create 5 **classic** leaderboards before this works end-to-end (exact parameters in the issue comment on #11). Until then the screen shows `ERR: leaderboard_not_configured` with retry — graceful, no crash.

## Test plan

- [x] 2 new unit tests (`LeaderboardConstantsTests`): ID mapping incl. fallback, whole-second conversion with zero/negative/sub-second guards
- [x] Full suite: 40/40 passed on iPhone 17 Pro simulator
- [ ] End-to-end on device after ASC boards exist (submit a solve, check both boards)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)