### PR TITLE
feat: breach-log loading + three-act victory sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Conflicting placements shake the cell with a short CRT-glitch jitter alongside the error haptic; disabled under Reduce Motion (#9)
 - The selection frame is now a single shared rectangle that glides between cells with a spring instead of jumping; instant under Reduce Motion (#10)
 - Game Center leaderboards: global ELO ranking plus per-difficulty fastest-time boards; victories submit the solve time (whole seconds) and rating gains submit the new ELO; terminal-styled leaderboard screen (`cat /leaderboard` in the profile) with guest sign-in notice and `GKAccessPoint` fallback (#11)
+- Breach-log loading screen: puzzle generation now plays a typewriter terminal log (`$ sudo breach --target=grid_9x9`) whose verdict lines report the real uniqueness check and difficulty index; instant under Reduce Motion (#12)
+- Victory sequence rework: real matrix rain (TimelineView + Canvas), typewriter `ACCESS GRANTED`, ELO ticker rolling to the new value with a rank-up ceremony on tier crossings; dismissed by tap instead of a 2-second timer; fade-only under Reduce Motion (#13)
 - `SudoSodokuTests` unit test target covering puzzle generation (solvability, unique solution, difficulty scoring), ELO rating (K-factor tiers, anti-smurfing), and storage (persistence roundtrip, legacy save migration)
 - Shared `SudoSodoku` scheme with test action, enabling `xcodebuild test` and Xcode Cloud test workflows
 

--- a/SudoSodoku/Views/Components/BreachLogView.swift
+++ b/SudoSodoku/Views/Components/BreachLogView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// The lines of the fake breach log shown while a puzzle generates.
+/// Pure so the script itself is unit-testable.
+enum BreachScript {
+    static let lineWidth = 30
+
+    static func introLines(difficulty: Difficulty) -> [String] {
+        [
+            "$ sudo breach --target=grid_9x9 --\(difficulty.rawValue.lowercased())",
+            padded("> requesting root access", status: "OK"),
+            padded("> generating entropy", status: "OK"),
+            padded("> digging holes", status: "OK"),
+        ]
+    }
+
+    static func finalLines(score: Int, difficulty: Difficulty) -> [String] {
+        [
+            padded("> uniqueness check", status: "PASS"),
+            "> difficulty_index: \(score) [\(difficulty.rawValue)]",
+        ]
+    }
+
+    /// Dot-leader padding: `> generating entropy.......... OK`
+    static func padded(_ text: String, status: String) -> String {
+        let dots = max(2, lineWidth - text.count)
+        return text + String(repeating: ".", count: dots) + " " + status
+    }
+}
+
+/// Typewriter breach log that doubles as the loading screen: intro lines
+/// reveal while the generator works, the verdict lines land once it finishes,
+/// then `onFinished` hands the screen back to the board.
+struct BreachLogView: View {
+    let difficulty: Difficulty
+    let isGenerating: Bool
+    let finalScore: Int
+    var onFinished: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var revealedCount = 0
+    @State private var cursorVisible = true
+
+    private var introLines: [String] { BreachScript.introLines(difficulty: difficulty) }
+    private var allLines: [String] {
+        isGenerating
+            ? introLines
+            : introLines + BreachScript.finalLines(score: finalScore, difficulty: difficulty)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(Array(allLines.prefix(revealedCount).enumerated()), id: \.offset) { _, line in
+                Text(line)
+                    .font(.system(size: 13, weight: .bold, design: .monospaced))
+                    .foregroundColor(color(for: line))
+            }
+            if revealedCount < allLines.count || isGenerating {
+                Text("_")
+                    .font(.system(size: 13, weight: .bold, design: .monospaced))
+                    .foregroundColor(.green)
+                    .opacity(cursorVisible ? 1 : 0)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 30)
+        .onAppear {
+            if reduceMotion {
+                revealedCount = allLines.count
+            } else {
+                withAnimation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true)) {
+                    cursorVisible = false
+                }
+            }
+        }
+        .task(id: isGenerating) { await run() }
+    }
+
+    private func color(for line: String) -> Color {
+        if line.hasSuffix("PASS") { return .green }
+        if line.hasPrefix("$") { return .white }
+        return .green.opacity(0.75)
+    }
+
+    private func run() async {
+        if reduceMotion {
+            revealedCount = allLines.count
+            if !isGenerating { onFinished() }
+            return
+        }
+
+        while revealedCount < allLines.count {
+            try? await Task.sleep(for: .milliseconds(revealedCount == 0 ? 50 : 170))
+            guard !Task.isCancelled else { return }
+            revealedCount = min(revealedCount + 1, allLines.count)
+        }
+
+        // Verdict lines are on screen; hold a beat, then hand back the board.
+        if !isGenerating {
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled else { return }
+            onFinished()
+        }
+    }
+}

--- a/SudoSodoku/Views/Components/MatrixVictoryOverlay.swift
+++ b/SudoSodoku/Views/Components/MatrixVictoryOverlay.swift
@@ -1,44 +1,157 @@
 import SwiftUI
 
+/// Three-act victory sequence: matrix rain, typewriter "ACCESS GRANTED",
+/// then the ELO ticker rolling to the new value (with a rank-up ceremony
+/// when a tier boundary was crossed). Dismissed by tap, never by timer.
 struct MatrixVictoryOverlay: View {
-    @State private var opacity = 0.0
-    @State private var scale = 0.8
+    let ratingGained: Int
+    let newRating: Int
+    var onDismiss: () -> Void
 
-    private let characters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ<>?[]{}"
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var typedCount = 0
+    @State private var displayedRating = 0
+    @State private var showRating = false
+    @State private var showHint = false
+
+    private let title = "ACCESS GRANTED"
+
+    private var oldRating: Int { newRating - max(0, ratingGained) }
+    private var didRankUp: Bool { RankTier.tier(for: oldRating) != RankTier.tier(for: newRating) }
+    private var newTier: RankTier { RankTier.tier(for: newRating) }
 
     var body: some View {
         ZStack {
             Color.black.opacity(0.95).ignoresSafeArea()
-            VStack {
-                ForEach(0..<10, id: \.self) { _ in
-                    HStack {
-                        ForEach(0..<15, id: \.self) { _ in
-                            Text(String(characters.randomElement()!))
-                                .font(.system(size: 14, design: .monospaced))
-                                .foregroundColor(Color.green.opacity(Double.random(in: 0.2...0.8)))
+
+            if !reduceMotion {
+                MatrixRain().opacity(0.35)
+            }
+
+            VStack(spacing: 18) {
+                Text(String(title.prefix(typedCount)))
+                    .font(.system(size: 38, weight: .heavy, design: .monospaced))
+                    .foregroundColor(.green)
+                    .shadow(color: .green, radius: 18)
+                    .frame(height: 46)
+
+                if typedCount == title.count {
+                    Text("SYSTEM COMPROMISED")
+                        .font(.system(size: 15, weight: .bold, design: .monospaced))
+                        .foregroundColor(.white)
+                }
+
+                if showRating {
+                    VStack(spacing: 8) {
+                        HStack(spacing: 10) {
+                            Text("ELO:")
+                                .font(.system(size: 20, weight: .bold, design: .monospaced))
+                                .foregroundColor(.gray)
+                            Text("\(displayedRating)")
+                                .font(.system(size: 28, weight: .heavy, design: .monospaced))
+                                .foregroundColor(.green)
+                                .contentTransition(.numericText(value: Double(displayedRating)))
+                            if ratingGained > 0 {
+                                Text("+\(ratingGained)")
+                                    .font(.system(size: 16, weight: .bold, design: .monospaced))
+                                    .foregroundColor(.yellow)
+                            }
                         }
+                        if ratingGained == 0 {
+                            Text("LOW DIFFICULTY // NO GAIN")
+                                .font(.system(size: 12, design: .monospaced))
+                                .foregroundColor(.gray)
+                        }
+                        if didRankUp {
+                            Text(">> RANK_UP: \(newTier.title) <<")
+                                .font(.system(size: 18, weight: .heavy, design: .monospaced))
+                                .foregroundColor(newTier.color)
+                                .shadow(color: newTier.color, radius: 12)
+                        }
+                    }
+                    .transition(.opacity)
+                }
+
+                if showHint {
+                    Text("[TAP_TO_CONTINUE]")
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(.gray)
+                        .padding(.top, 14)
+                }
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { onDismiss() }
+        .task { await runSequence() }
+    }
+
+    private func runSequence() async {
+        if reduceMotion {
+            typedCount = title.count
+            displayedRating = newRating
+            showRating = true
+            showHint = true
+            return
+        }
+
+        for count in 1...title.count {
+            typedCount = count
+            try? await Task.sleep(for: .milliseconds(50))
+            guard !Task.isCancelled else { return }
+        }
+
+        displayedRating = oldRating
+        withAnimation(.easeIn(duration: 0.2)) { showRating = true }
+        try? await Task.sleep(for: .milliseconds(300))
+        guard !Task.isCancelled else { return }
+
+        withAnimation(.easeOut(duration: 0.9)) { displayedRating = newRating }
+        try? await Task.sleep(for: .milliseconds(1100))
+        guard !Task.isCancelled else { return }
+
+        withAnimation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true)) {
+            showHint = true
+        }
+    }
+}
+
+/// Falling character columns drawn on a Canvas — far cheaper than stacks of
+/// Text views. Deterministic per-column pseudo-randomness keeps it allocation
+/// free across frames.
+private struct MatrixRain: View {
+    private static let glyphs = Array("0123456789ABCDEF<>[]{}$#")
+
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 24.0)) { timeline in
+            Canvas { context, size in
+                let time = timeline.date.timeIntervalSinceReferenceDate
+                let columnWidth: CGFloat = 16
+                let rowHeight: CGFloat = 16
+                let columns = max(1, Int(size.width / columnWidth))
+                let travel = Double(size.height) + 240
+
+                for column in 0..<columns {
+                    let speed = 70.0 + Double((column * 37) % 70)
+                    let offset = Double((column * 131) % 997)
+                    let headY = CGFloat((time * speed + offset).truncatingRemainder(dividingBy: travel)) - 120
+                    let x = CGFloat(column) * columnWidth + columnWidth / 2
+
+                    for row in 0..<14 {
+                        let y = headY - CGFloat(row) * rowHeight
+                        guard y > -20, y < size.height + 20 else { continue }
+                        let glyphIndex = abs(column &* 31 &+ row &* 17 &+ Int(time * 9)) % Self.glyphs.count
+                        let alpha = row == 0 ? 0.95 : max(0.05, 0.7 - Double(row) * 0.05)
+                        context.draw(
+                            Text(String(Self.glyphs[glyphIndex]))
+                                .font(.system(size: 13, design: .monospaced))
+                                .foregroundColor(.green.opacity(alpha)),
+                            at: CGPoint(x: x, y: y)
+                        )
                     }
                 }
             }
-            .opacity(0.3)
-
-            VStack(spacing: 20) {
-                Text("ACCESS GRANTED")
-                    .font(.system(size: 40, weight: .heavy, design: .monospaced))
-                    .foregroundColor(.green)
-                    .shadow(color: .green, radius: 20)
-                    .scaleEffect(scale)
-
-                Text("SYSTEM COMPROMISED")
-                    .font(.system(size: 16, weight: .bold, design: .monospaced))
-                    .foregroundColor(.white)
-                    .padding(.top, 10)
-            }
         }
-        .opacity(opacity)
-        .onAppear {
-            withAnimation(.easeIn(duration: 0.2)) { opacity = 1.0; scale = 1.1 }
-            withAnimation(.easeInOut(duration: 0.1).repeatForever()) { scale = 1.0 }
-        }
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
     }
 }

--- a/SudoSodoku/Views/GameView.swift
+++ b/SudoSodoku/Views/GameView.swift
@@ -15,6 +15,7 @@ struct GameView: View {
 
     @AppStorage("showPlayTimer") private var showPlayTimer = true
     @State private var clockNow = Date()
+    @State private var showBreachLog = false
     private let clockTicker = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     enum ExitAction {
@@ -39,11 +40,13 @@ struct GameView: View {
             TerminalBackground()
                 .onTapGesture { game.selectedCellIndex = nil }
 
-            if game.isGenerating {
-                VStack(spacing: 20) {
-                    ProgressView().progressViewStyle(CircularProgressViewStyle(tint: .green)).scaleEffect(2)
-                    Text("LOADING DATA...").font(.system(size: 16, design: .monospaced)).foregroundColor(.green)
-                }
+            if game.isGenerating || showBreachLog {
+                BreachLogView(
+                    difficulty: game.difficulty,
+                    isGenerating: game.isGenerating,
+                    finalScore: game.currentScore,
+                    onFinished: { withAnimation(.easeOut(duration: 0.2)) { showBreachLog = false } }
+                )
             } else {
                 VStack(spacing: 10) {
                     HStack(spacing: 12) {
@@ -137,10 +140,20 @@ struct GameView: View {
                 }
             }
 
-            if showVictoryAnimation { MatrixVictoryOverlay().zIndex(100) }
+            if showVictoryAnimation {
+                MatrixVictoryOverlay(
+                    ratingGained: game.ratingGained ?? 0,
+                    newRating: StorageManager.shared.userRating,
+                    onDismiss: { withAnimation(.easeOut(duration: 0.25)) { showVictoryAnimation = false } }
+                )
+                .zIndex(100)
+            }
         }
         .navigationBarHidden(true)
         .onReceive(clockTicker) { clockNow = $0 }
+        .onChange(of: game.isGenerating) { _, generating in
+            if generating { showBreachLog = true }
+        }
         .onChange(of: scenePhase) { _, phase in
             switch phase {
             case .background, .inactive:
@@ -157,15 +170,13 @@ struct GameView: View {
 
             game.onSolved = {
                 withAnimation { showVictoryAnimation = true }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                    withAnimation { showVictoryAnimation = false }
-                }
             }
 
             if let record {
                 game.loadFromRecord(record)
                 if record.isSolved { game.showSolution() }
             } else if let difficulty {
+                showBreachLog = true
                 game.generateGame(for: difficulty)
             }
         }

--- a/SudoSodokuTests/BreachScriptTests.swift
+++ b/SudoSodokuTests/BreachScriptTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import SudoSodoku
+
+final class BreachScriptTests: XCTestCase {
+
+    func testIntroLinesTargetTheRequestedDifficulty() {
+        let lines = BreachScript.introLines(difficulty: .master)
+        XCTAssertEqual(lines.first, "$ sudo breach --target=grid_9x9 --master")
+        XCTAssertTrue(lines.dropFirst().allSatisfy { $0.hasSuffix(" OK") },
+                      "Every intro step must report OK")
+    }
+
+    func testFinalLinesReportVerdictAndRealScore() {
+        let lines = BreachScript.finalLines(score: 82, difficulty: .master)
+        XCTAssertTrue(lines[0].hasSuffix(" PASS"))
+        XCTAssertEqual(lines[1], "> difficulty_index: 82 [MASTER]")
+    }
+
+    func testDotLeaderPaddingAlignsStatusColumn() {
+        let short = BreachScript.padded("> a", status: "OK")
+        let long = BreachScript.padded("> generating entropy", status: "OK")
+        // Same visual column: text + dots always spans lineWidth characters.
+        XCTAssertEqual(short.count - " OK".count, BreachScript.lineWidth)
+        XCTAssertEqual(long.count - " OK".count, BreachScript.lineWidth)
+        XCTAssertTrue(BreachScript.padded(String(repeating: "x", count: 40), status: "OK").contains(".."),
+                      "Overlong lines still keep a minimum dot leader")
+    }
+}


### PR DESCRIPTION
## Summary

The two signature moments of week 2 (Tier B):

**#12 — Breach-log loading screen**
- Generation now plays a typewriter terminal log: `$ sudo breach --target=grid_9x9 --master` → entropy/dig steps reveal while the generator actually works → verdict lines (`uniqueness check... PASS`, `difficulty_index: 82 [MASTER]`) land with the **real score** once generation finishes, hold 0.4s, then hand back the board
- Script lines live in a pure `BreachScript` enum (dot-leader alignment, per-difficulty target flag) so they're unit-tested
- Replays trigger no log; NEW TARGET regenerations do; Reduce Motion reveals instantly with no hold

**#13 — Victory sequence rework**
- Act 1: real falling-column matrix rain via `TimelineView` + `Canvas` (~330 glyph draws @24fps, allocation-free, replaces the old static random `Text` grid)
- Act 2: typewriter `ACCESS GRANTED`
- Act 3: ELO ticker rolls old → new (`contentTransition(.numericText)`), `+N` gain badge, and a glowing `>> RANK_UP: SUDOER <<` ceremony when a tier boundary is crossed — the game's biggest moment finally has ritual
- Dismissed by tap (`[TAP_TO_CONTINUE]` hint), not a fixed 2s timer; Reduce Motion gets a static fade-in panel with final values

## Test plan

- [x] 3 new unit tests (`BreachScriptTests`): difficulty flag in the command line, verdict/score content, dot-leader column alignment incl. overlong-line guard
- [x] Full suite: 43/43 passed on iPhone 17 Pro simulator
- [ ] Feel pass on device: generation log pacing (170ms/line) and rain density are tuning knobs in `BreachLogView` / `MatrixRain`

Closes #12
Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)