### PR TITLE
chore: debug-only factory reset (verify achievements on a played account)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SudoSodokuTests` unit test target covering puzzle generation (solvability, unique solution, difficulty scoring), ELO rating (K-factor tiers, anti-smurfing), and storage (persistence roundtrip, legacy save migration)
 - Shared `SudoSodoku` scheme with test action, enabling `xcodebuild test` and Xcode Cloud test workflows
 - Product identity: slogan "sudo solve — root access for logical purists", four-pillar philosophy in the README, and the tagline on the landing screen
+- Debug builds only: `$ rm -rf /user_data` factory reset in the profile (records, rating, achievements, sudoers-joke flag, and Game Center achievement progress via `resetAchievements`) for verifying first-run flows; compiled out of Release
 
 ### Changed
 

--- a/SudoSodoku/Managers/AchievementManager.swift
+++ b/SudoSodoku/Managers/AchievementManager.swift
@@ -39,6 +39,19 @@ final class AchievementManager: ObservableObject {
         unlock([.incidentReported])
     }
 
+    /// Clears local unlock state and, when signed in, asks Game Center to
+    /// reset server-side achievement progress. Used by the debug factory
+    /// reset so unlock flows can be re-verified on a played account.
+    func resetAllProgress() {
+        defaults.removeObject(forKey: unlockedKey)
+        defaults.removeObject(forKey: pendingReportsKey)
+        justUnlocked = []
+        objectWillChange.send()
+        if GameCenterManager.shared.isAuthenticated {
+            GKAchievement.resetAchievements { _ in }
+        }
+    }
+
     /// Called after Game Center authentication succeeds.
     func flushPendingReports() {
         let pending = defaults.stringArray(forKey: pendingReportsKey) ?? []

--- a/SudoSodoku/Managers/StorageManager.swift
+++ b/SudoSodoku/Managers/StorageManager.swift
@@ -68,6 +68,15 @@ class StorageManager: ObservableObject {
         persist()
     }
 
+    /// Factory reset: drops every record and returns the rating to the
+    /// starting 1200. Persists immediately so legacy files can't resurrect
+    /// the old state on next launch.
+    func wipeAllData() {
+        records = []
+        userRating = 1200
+        persist()
+    }
+
     func loadData() {
         let currentURL = getFileURL(name: currentFileName)
 

--- a/SudoSodoku/Views/UserProfileView.swift
+++ b/SudoSodoku/Views/UserProfileView.swift
@@ -5,6 +5,10 @@ struct UserProfileView: View {
     @ObservedObject private var stats = StatisticsManager.shared
     @ObservedObject private var achievements = AchievementManager.shared
 
+    #if DEBUG
+    @State private var showWipeConfirmation = false
+    #endif
+
     private var ratingInfo: (title: String, color: Color) {
         RatingManager.shared.getRankTitle(rating: storage.userRating)
     }
@@ -65,12 +69,47 @@ struct UserProfileView: View {
                         }
                     }.padding().background(Color.white.opacity(0.05)).cornerRadius(12).padding(.horizontal)
 
+                    #if DEBUG
+                    debugWipeButton
+                    #endif
+
                     Spacer()
                 }
             }
         }
         .navigationBarTitleDisplayMode(.inline)
     }
+
+    #if DEBUG
+    /// Debug builds only: factory reset for verifying first-run flows
+    /// (achievement unlocks, the sudoers joke) on an already-played account.
+    private var debugWipeButton: some View {
+        Button(role: .destructive, action: { showWipeConfirmation = true }) {
+            HStack {
+                Image(systemName: "trash")
+                Text("$ rm -rf /user_data")
+            }
+            .font(.system(size: 14, weight: .bold, design: .monospaced))
+            .foregroundColor(.red)
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity)
+            .background(Color.red.opacity(0.08))
+            .cornerRadius(12)
+            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.red.opacity(0.4), lineWidth: 1))
+        }
+        .padding(.horizontal)
+        .confirmationDialog("WIPE_USER_DATA?", isPresented: $showWipeConfirmation, titleVisibility: .visible) {
+            Button("CONFIRM (irreversible)", role: .destructive) {
+                StorageManager.shared.wipeAllData()
+                AchievementManager.shared.resetAllProgress()
+                UserDefaults.standard.removeObject(forKey: SudoersJoke.seenKey)
+            }
+            Button("CANCEL", role: .cancel) {}
+        } message: {
+            Text("Erases local records and rating, clears achievements, and resets Game Center achievement progress.")
+        }
+    }
+    #endif
 
     @ViewBuilder
     private func achievementRow(_ achievement: Achievement) -> some View {

--- a/SudoSodokuTests/UserDataResetTests.swift
+++ b/SudoSodokuTests/UserDataResetTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import SudoSodoku
+
+final class UserDataResetTests: XCTestCase {
+
+    private let currentFileName = "save_data_v4.json"
+    private let suiteName = "UserDataResetTests"
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: saveURL())
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: saveURL())
+        super.tearDown()
+    }
+
+    func testWipeAllDataResetsRecordsRatingAndPersists() throws {
+        let manager = StorageManager()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        manager.saveGame(makeRecord())
+        manager.updateUserRating(add: 300)
+        XCTAssertEqual(manager.userRating, 1500)
+        XCTAssertEqual(manager.records.count, 1)
+
+        manager.wipeAllData()
+
+        XCTAssertTrue(manager.records.isEmpty)
+        XCTAssertEqual(manager.userRating, 1200)
+
+        let data = try Data(contentsOf: saveURL())
+        let container = try JSONDecoder().decode(StorageManager.StorageContainer.self, from: data)
+        XCTAssertEqual(container.rating, 1200, "The wipe must be persisted, not just in-memory")
+        XCTAssertTrue(container.records.isEmpty)
+    }
+
+    func testAchievementResetClearsLocalStateAndAllowsReUnlock() {
+        let manager = AchievementManager(defaults: defaults)
+        manager.unlockIncidentReported()
+        XCTAssertTrue(manager.isUnlocked(.incidentReported))
+
+        manager.resetAllProgress()
+
+        XCTAssertFalse(manager.isUnlocked(.incidentReported))
+        XCTAssertTrue(manager.justUnlocked.isEmpty)
+        XCTAssertNil(defaults.stringArray(forKey: "pendingAchievementReports"),
+                     "The offline report queue must be cleared too")
+
+        manager.unlockIncidentReported()
+        XCTAssertEqual(manager.justUnlocked, [.incidentReported],
+                       "After a reset the unlock must announce again")
+    }
+
+    // MARK: - Fixtures
+
+    private func saveURL() -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(currentFileName)
+    }
+
+    private func makeRecord() -> GameRecord {
+        GameRecord(
+            id: UUID(),
+            startTime: Date(),
+            lastPlayedTime: Date(),
+            difficulty: "EASY",
+            difficultyIndex: 10,
+            initialBoard: Array(repeating: 0, count: 81),
+            solution: Array(repeating: 1, count: 81),
+            playerBoard: Array(repeating: 0, count: 81),
+            playerNotes: nil,
+            isSolved: true,
+            ratingChange: 10
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Kai can't verify achievement unlock flows because his Game Center account has already played — `HELLO_WORLD` and friends are permanently earned. This adds the missing reset lever, gated to where it can't hurt:

**Where user data lives (for the record)**
| Data | Location | Cleared by app delete? |
|---|---|---|
| Records + ELO | `save_data_v4.json` (app Documents) | yes |
| Unlocked achievements + offline report queue | `UserDefaults` | yes |
| sudoers-joke flag, timer toggle | `UserDefaults` | yes |
| Achievement progress | **Game Center servers** | **no** |

**The reset** — `$ rm -rf /user_data` in the profile, `#if DEBUG` only:
- `StorageManager.wipeAllData()`: records dropped, rating back to 1200, persisted immediately so legacy files can't resurrect state
- `AchievementManager.resetAllProgress()`: local unlock set + pending queue cleared, `GKAchievement.resetAchievements` when signed in (Apple's official server-side reset)
- sudoers joke re-armed
- Confirmation dialog before anything happens; the whole surface is compiled out of Release/TestFlight builds

Leaderboard scores are the one thing the client can't reset (no API); since the boards aren't live yet, delete-and-recreate in ASC is the option if ever needed.

## Test plan

- [x] 2 new unit tests: wipe resets + persists (verified on disk), achievement reset clears state/queue and allows re-announcing unlocks
- [x] Full suite: 63/63 passed
- [x] Release build for `generic/platform=iOS`: **BUILD SUCCEEDED** — debug surface compiles out cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)