### PR TITLE
fix: achievement unlocks were invisible (show them in the victory sequence)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Achievement unlocks had no visible feedback: the toast raced the victory overlay and could expire unseen behind the matrix rain. Unlocks now render inside the victory sequence itself (`>> UNLOCKED: ...` under the ELO ticker), and the sudoers interstitial types out its own secret-achievement line — the separate toast and its cross-view choreography are gone
 - Pinned `IPHONEOS_DEPLOYMENT_TARGET` back to the literal `17.0` on all targets: Xcode's "Update to recommended settings" had rewritten it to `$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)`, which Xcode Cloud's toolchain resolves to nothing, dropping the deployment target to the SDK floor and failing builds with iOS 16/17 availability errors
 
 ### Removed

--- a/SudoSodoku/Managers/AchievementManager.swift
+++ b/SudoSodoku/Managers/AchievementManager.swift
@@ -4,11 +4,10 @@ import GameKit
 
 /// Owns the unlocked-achievement set: evaluates victories, persists locally,
 /// reports to Game Center, and queues reports made while signed out.
+/// Callers receive freshly unlocked achievements as return values and own
+/// their presentation — there is no cross-view announcement state.
 final class AchievementManager: ObservableObject {
     static let shared = AchievementManager()
-
-    /// Achievements unlocked by the most recent event, for the in-game toast.
-    @Published private(set) var justUnlocked: [Achievement] = []
 
     private let defaults: UserDefaults
     private let unlockedKey = "unlockedAchievements"
@@ -30,12 +29,16 @@ final class AchievementManager: ObservableObject {
 
     // MARK: - Events
 
-    func evaluateVictory(_ context: VictoryContext) {
+    /// Returns the achievements this victory freshly unlocked (empty when
+    /// everything satisfied was already earned).
+    @discardableResult
+    func evaluateVictory(_ context: VictoryContext) -> [Achievement] {
         unlock(Achievement.satisfied(by: context))
     }
 
     /// Easter egg hook for the sudoers interstitial (#15).
-    func unlockIncidentReported() {
+    @discardableResult
+    func unlockIncidentReported() -> [Achievement] {
         unlock([.incidentReported])
     }
 
@@ -45,7 +48,6 @@ final class AchievementManager: ObservableObject {
     func resetAllProgress() {
         defaults.removeObject(forKey: unlockedKey)
         defaults.removeObject(forKey: pendingReportsKey)
-        justUnlocked = []
         objectWillChange.send()
         if GameCenterManager.shared.isAuthenticated {
             GKAchievement.resetAchievements { _ in }
@@ -62,14 +64,14 @@ final class AchievementManager: ObservableObject {
 
     // MARK: - Internals
 
-    private func unlock(_ candidates: [Achievement]) {
+    private func unlock(_ candidates: [Achievement]) -> [Achievement] {
         let fresh = candidates.filter { !isUnlocked($0) }
-        guard !fresh.isEmpty else { return }
+        guard !fresh.isEmpty else { return [] }
 
         defaults.set(Array(unlockedIDs.union(fresh.map(\.rawValue))), forKey: unlockedKey)
         objectWillChange.send()
-        justUnlocked = fresh
         report(fresh)
+        return fresh
     }
 
     private func report(_ achievements: [Achievement]) {

--- a/SudoSodoku/ViewModels/SudokuGame.swift
+++ b/SudoSodoku/ViewModels/SudokuGame.swift
@@ -35,6 +35,10 @@ class SudokuGame: ObservableObject {
     /// removals, notes, and undo leave it untouched.
     @Published private(set) var streak = 0
 
+    /// Achievements freshly unlocked by the current victory, rendered inside
+    /// the victory overlay (never as a separate toast that could race it).
+    @Published private(set) var victoryUnlocks: [Achievement] = []
+
     var onSolved: (() -> Void)?
     var currentRecordID: UUID?
 
@@ -90,6 +94,7 @@ class SudokuGame: ObservableObject {
         self.sessionStartTime = Date()
         self.completedUnitPulse = nil
         self.streak = 0
+        self.victoryUnlocks = []
 
         DispatchQueue.global(qos: .userInitiated).async {
             let (puzzle, solution, score) = SudokuGenerator.generatePuzzle(targetDifficulty: difficulty)
@@ -132,6 +137,7 @@ class SudokuGame: ObservableObject {
         currentUndoCount = record.undoCount
         completedUnitPulse = nil
         streak = 0
+        victoryUnlocks = []
 
         board = (0..<81).map { index in
             let initialValue = record.initialBoard[index]
@@ -379,6 +385,7 @@ class SudokuGame: ObservableObject {
         sessionStartTime = Date()
         completedUnitPulse = nil
         streak = 0
+        victoryUnlocks = []
         resetClock(to: 0, running: true)
         saveCurrentState()
     }
@@ -463,7 +470,7 @@ class SudokuGame: ObservableObject {
         saveCurrentState()
 
         // After saveCurrentState so the solved count includes this game.
-        AchievementManager.shared.evaluateVictory(VictoryContext(
+        victoryUnlocks = AchievementManager.shared.evaluateVictory(VictoryContext(
             difficulty: difficulty,
             undoCount: currentUndoCount,
             playDuration: playDuration(),

--- a/SudoSodoku/Views/Components/MatrixVictoryOverlay.swift
+++ b/SudoSodoku/Views/Components/MatrixVictoryOverlay.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct MatrixVictoryOverlay: View {
     let ratingGained: Int
     let newRating: Int
+    let unlockedAchievements: [Achievement]
     var onDismiss: () -> Void
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -67,6 +68,16 @@ struct MatrixVictoryOverlay: View {
                                 .font(.system(size: 18, weight: .heavy, design: .monospaced))
                                 .foregroundColor(newTier.color)
                                 .shadow(color: newTier.color, radius: 12)
+                        }
+                        if !unlockedAchievements.isEmpty {
+                            VStack(alignment: .leading, spacing: 4) {
+                                ForEach(unlockedAchievements) { achievement in
+                                    Text(">> UNLOCKED: \(achievement.title)")
+                                        .font(.system(size: 13, weight: .bold, design: .monospaced))
+                                        .foregroundColor(.yellow)
+                                }
+                            }
+                            .padding(.top, 6)
                         }
                     }
                     .transition(.opacity)

--- a/SudoSodoku/Views/Components/SudoersInterstitial.swift
+++ b/SudoSodoku/Views/Components/SudoersInterstitial.swift
@@ -23,6 +23,7 @@ struct SudoersInterstitial: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var showPunchline = false
     @State private var typedCount = 0
+    @State private var showAchievement = false
     @State private var finished = false
 
     private let punchline = "...just kidding. root access granted."
@@ -36,6 +37,9 @@ struct SudoersInterstitial: View {
             Text(String(punchline.prefix(typedCount)))
                 .foregroundColor(.green)
                 .opacity(showPunchline ? 1 : 0)
+            Text(">> UNLOCKED: \(Achievement.incidentReported.title)")
+                .foregroundColor(.yellow)
+                .opacity(showAchievement ? 1 : 0)
         }
         .font(.system(size: 14, weight: .bold, design: .monospaced))
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
@@ -48,7 +52,8 @@ struct SudoersInterstitial: View {
         if reduceMotion {
             showPunchline = true
             typedCount = punchline.count
-            try? await Task.sleep(for: .seconds(2))
+            showAchievement = true
+            try? await Task.sleep(for: .seconds(2.4))
             finish()
             return
         }
@@ -61,7 +66,10 @@ struct SudoersInterstitial: View {
             try? await Task.sleep(for: .milliseconds(40))
             guard !Task.isCancelled, !finished else { return }
         }
-        try? await Task.sleep(for: .milliseconds(700))
+        try? await Task.sleep(for: .milliseconds(350))
+        guard !Task.isCancelled, !finished else { return }
+        withAnimation(.easeIn(duration: 0.25)) { showAchievement = true }
+        try? await Task.sleep(for: .milliseconds(900))
         finish()
     }
 

--- a/SudoSodoku/Views/GameView.swift
+++ b/SudoSodoku/Views/GameView.swift
@@ -18,9 +18,6 @@ struct GameView: View {
     @State private var showBreachLog = false
     @State private var showSudoersJoke = false
 
-    @ObservedObject private var achievements = AchievementManager.shared
-    @State private var toastText: String?
-    @State private var pendingToast: String?
     private let clockTicker = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     enum ExitAction {
@@ -169,36 +166,13 @@ struct GameView: View {
                 MatrixVictoryOverlay(
                     ratingGained: game.ratingGained ?? 0,
                     newRating: StorageManager.shared.userRating,
+                    unlockedAchievements: game.victoryUnlocks,
                     onDismiss: { withAnimation(.easeOut(duration: 0.25)) { showVictoryAnimation = false } }
                 )
                 .zIndex(100)
             }
-
-            if let toastText {
-                Text(toastText)
-                    .font(.system(size: 12, weight: .bold, design: .monospaced))
-                    .foregroundColor(.green)
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 8)
-                    .background(Color.black.opacity(0.85))
-                    .cornerRadius(8)
-                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.green.opacity(0.6), lineWidth: 1))
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                    .padding(.top, 60)
-                    .transition(.opacity)
-                    .zIndex(50)
-            }
         }
         .navigationBarHidden(true)
-        .onChange(of: achievements.justUnlocked) { _, unlocked in
-            guard let first = unlocked.first else { return }
-            let suffix = unlocked.count > 1 ? " +\(unlocked.count - 1)" : ""
-            pendingToast = ">> ACHIEVEMENT: \(first.title)\(suffix)"
-            if !showVictoryAnimation { presentToast() }
-        }
-        .onChange(of: showVictoryAnimation) { _, showing in
-            if !showing { presentToast() }
-        }
         .onReceive(clockTicker) { clockNow = $0 }
         .onChange(of: game.isGenerating) { _, generating in
             if generating { showBreachLog = true }
@@ -241,16 +215,6 @@ struct GameView: View {
             Button("DISCARD (Delete)", role: .destructive) { game.discardCurrentRecord(); performPendingAction() }
             Button("CANCEL", role: .cancel) { pendingExitAction = nil }
         } message: { Text("Do you want to save this session to your archives?") }
-    }
-
-    private func presentToast() {
-        guard let text = pendingToast else { return }
-        pendingToast = nil
-        withAnimation(.easeIn(duration: 0.2)) { toastText = text }
-        Task {
-            try? await Task.sleep(for: .seconds(2.6))
-            withAnimation(.easeOut(duration: 0.3)) { toastText = nil }
-        }
     }
 
     private func handleExitRequest(_ action: ExitAction) {

--- a/SudoSodokuTests/AchievementManagerTests.swift
+++ b/SudoSodokuTests/AchievementManagerTests.swift
@@ -52,20 +52,19 @@ final class AchievementManagerTests: XCTestCase {
     // MARK: - Manager state
 
     func testUnlockPersistsAndNeverRepeats() {
-        manager.evaluateVictory(context(totalSolved: 1))
+        let first = manager.evaluateVictory(context(totalSolved: 1))
+        XCTAssertEqual(first, [.helloWorld])
         XCTAssertTrue(manager.isUnlocked(.helloWorld))
-        XCTAssertEqual(manager.justUnlocked, [.helloWorld])
 
-        manager.evaluateVictory(context(totalSolved: 2))
-        XCTAssertEqual(manager.justUnlocked, [.helloWorld],
-                       "A repeat victory must not re-announce old unlocks")
+        let repeated = manager.evaluateVictory(context(totalSolved: 2))
+        XCTAssertTrue(repeated.isEmpty, "A repeat victory must not re-announce old unlocks")
         XCTAssertEqual(defaults.stringArray(forKey: "unlockedAchievements")?.count, 1)
     }
 
     func testIncidentReportedIsAOneShotEasterEgg() {
-        manager.unlockIncidentReported()
+        XCTAssertEqual(manager.unlockIncidentReported(), [.incidentReported])
         XCTAssertTrue(manager.isUnlocked(.incidentReported))
-        XCTAssertEqual(manager.justUnlocked, [.incidentReported])
+        XCTAssertTrue(manager.unlockIncidentReported().isEmpty, "Second trigger returns nothing new")
     }
 
     func testUnauthenticatedUnlocksQueueForLaterReport() {

--- a/SudoSodokuTests/UserDataResetTests.swift
+++ b/SudoSodokuTests/UserDataResetTests.swift
@@ -47,12 +47,10 @@ final class UserDataResetTests: XCTestCase {
         manager.resetAllProgress()
 
         XCTAssertFalse(manager.isUnlocked(.incidentReported))
-        XCTAssertTrue(manager.justUnlocked.isEmpty)
         XCTAssertNil(defaults.stringArray(forKey: "pendingAchievementReports"),
                      "The offline report queue must be cleared too")
 
-        manager.unlockIncidentReported()
-        XCTAssertEqual(manager.justUnlocked, [.incidentReported],
+        XCTAssertEqual(manager.unlockIncidentReported(), [.incidentReported],
                        "After a reset the unlock must announce again")
     }
 


### PR DESCRIPTION
## Root cause

Unlocks recorded fine (wall + Game Center) but never showed feedback. The toast and the victory overlay were driven by two state changes landing in the same transaction, coordinated by two `onChange` handlers plus a deferral flag — and the losing interleaving presents the toast while the matrix-rain overlay (zIndex 100) covers it (zIndex 50). Its 2.6s timer then expires unseen, and the deferred re-present finds `pendingToast` already consumed. Choreography like this is inherently racy.

## Fix — ownership instead of choreography

- Victory unlocks render **inside the victory sequence**: `>> UNLOCKED: HELLO_WORLD` lines (yellow) under the ELO ticker, fed by `SudokuGame.victoryUnlocks` — captured per victory from `evaluateVictory`'s new return value, reset on new game/load/replay
- The sudoers interstitial types out its own `>> UNLOCKED: INCIDENT_REPORTED` line as part of its script
- Deleted: the toast view, `pendingToast`/`presentToast` deferral logic, both `onChange` handlers, and `AchievementManager.justUnlocked` (callers now own presentation via return values — less shared state)

Net: 49 insertions, 59 deletions — the fix removes more than it adds.

## Test plan

- [x] `AchievementManagerTests` / `UserDataResetTests` updated to assert on return values (stronger than the old published-property checks)
- [x] Full suite: 63/63 passed (re-run after rebase onto main)
- [ ] Device: debug-wipe, win a game → `ACCESS GRANTED` panel now lists the unlocks; first MASTER shows the incident line

🤖 Generated with [Claude Code](https://claude.com/claude-code)