### PR TITLE
fix: achievement unlocks get badge-level presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Achievement unlocks had no visible feedback: the toast raced the victory overlay and could expire unseen behind the matrix rain. Unlocks now render inside the victory sequence itself (`>> UNLOCKED: ...` under the ELO ticker), and the sudoers interstitial types out its own secret-achievement line — the separate toast and its cross-view choreography are gone
+- Achievement unlocks had no visible feedback: the toast raced the victory overlay and could expire unseen behind the matrix rain. Unlocks now render inside the victory sequence itself, and the sudoers interstitial shows its own secret-achievement unlock — the separate toast and its cross-view choreography are gone
+- Unlock display upgraded from a single small text line to a proper badge: bordered glowing card (`ACHIEVEMENT_UNLOCKED` + large title) popping in one per beat with a spring and a haptic tick, as the victory sequence's fourth act
 - Pinned `IPHONEOS_DEPLOYMENT_TARGET` back to the literal `17.0` on all targets: Xcode's "Update to recommended settings" had rewritten it to `$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)`, which Xcode Cloud's toolchain resolves to nothing, dropping the deployment target to the SDK floor and failing builds with iOS 16/17 availability errors
 
 ### Removed

--- a/SudoSodoku/Views/Components/AchievementBadge.swift
+++ b/SudoSodoku/Views/Components/AchievementBadge.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// The unlock badge: a bordered, glowing card that gives an achievement the
+/// presence a reward deserves. Shared by the victory sequence and the
+/// sudoers interstitial.
+struct AchievementBadge: View {
+    let achievement: Achievement
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text("ACHIEVEMENT_UNLOCKED")
+                .font(.system(size: 10, weight: .bold, design: .monospaced))
+                .foregroundColor(.yellow.opacity(0.7))
+                .tracking(2)
+            Text(achievement.title)
+                .font(.system(size: 21, weight: .heavy, design: .monospaced))
+                .foregroundColor(.yellow)
+                .shadow(color: .yellow.opacity(0.7), radius: 12)
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 22)
+        .background(Color.yellow.opacity(0.08))
+        .cornerRadius(10)
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.yellow.opacity(0.7), lineWidth: 1.5))
+    }
+}

--- a/SudoSodoku/Views/Components/MatrixVictoryOverlay.swift
+++ b/SudoSodoku/Views/Components/MatrixVictoryOverlay.swift
@@ -13,6 +13,7 @@ struct MatrixVictoryOverlay: View {
     @State private var typedCount = 0
     @State private var displayedRating = 0
     @State private var showRating = false
+    @State private var revealedBadges = 0
     @State private var showHint = false
 
     private let title = "ACCESS GRANTED"
@@ -69,18 +70,20 @@ struct MatrixVictoryOverlay: View {
                                 .foregroundColor(newTier.color)
                                 .shadow(color: newTier.color, radius: 12)
                         }
-                        if !unlockedAchievements.isEmpty {
-                            VStack(alignment: .leading, spacing: 4) {
-                                ForEach(unlockedAchievements) { achievement in
-                                    Text(">> UNLOCKED: \(achievement.title)")
-                                        .font(.system(size: 13, weight: .bold, design: .monospaced))
-                                        .foregroundColor(.yellow)
-                                }
-                            }
-                            .padding(.top, 6)
-                        }
                     }
                     .transition(.opacity)
+                }
+
+                // Act 4: unlock badges pop in one by one, each with its own
+                // haptic tick.
+                if revealedBadges > 0 {
+                    VStack(spacing: 10) {
+                        ForEach(unlockedAchievements.prefix(revealedBadges)) { achievement in
+                            AchievementBadge(achievement: achievement)
+                                .transition(.scale(scale: 0.8).combined(with: .opacity))
+                        }
+                    }
+                    .padding(.top, 8)
                 }
 
                 if showHint {
@@ -101,6 +104,7 @@ struct MatrixVictoryOverlay: View {
             typedCount = title.count
             displayedRating = newRating
             showRating = true
+            revealedBadges = unlockedAchievements.count
             showHint = true
             return
         }
@@ -119,6 +123,15 @@ struct MatrixVictoryOverlay: View {
         withAnimation(.easeOut(duration: 0.9)) { displayedRating = newRating }
         try? await Task.sleep(for: .milliseconds(1100))
         guard !Task.isCancelled else { return }
+
+        for _ in unlockedAchievements {
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.65)) {
+                revealedBadges += 1
+            }
+            HapticManager.shared.unitCompleted()
+            try? await Task.sleep(for: .milliseconds(450))
+            guard !Task.isCancelled else { return }
+        }
 
         withAnimation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true)) {
             showHint = true

--- a/SudoSodoku/Views/Components/SudoersInterstitial.swift
+++ b/SudoSodoku/Views/Components/SudoersInterstitial.swift
@@ -37,9 +37,11 @@ struct SudoersInterstitial: View {
             Text(String(punchline.prefix(typedCount)))
                 .foregroundColor(.green)
                 .opacity(showPunchline ? 1 : 0)
-            Text(">> UNLOCKED: \(Achievement.incidentReported.title)")
-                .foregroundColor(.yellow)
-                .opacity(showAchievement ? 1 : 0)
+            if showAchievement {
+                AchievementBadge(achievement: .incidentReported)
+                    .padding(.top, 14)
+                    .transition(.scale(scale: 0.8).combined(with: .opacity))
+            }
         }
         .font(.system(size: 14, weight: .bold, design: .monospaced))
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
@@ -68,8 +70,9 @@ struct SudoersInterstitial: View {
         }
         try? await Task.sleep(for: .milliseconds(350))
         guard !Task.isCancelled, !finished else { return }
-        withAnimation(.easeIn(duration: 0.25)) { showAchievement = true }
-        try? await Task.sleep(for: .milliseconds(900))
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.65)) { showAchievement = true }
+        HapticManager.shared.unitCompleted()
+        try? await Task.sleep(for: .milliseconds(1200))
         finish()
     }
 


### PR DESCRIPTION
## Summary

Feedback from device testing: the unlock line (13pt yellow text) was too small and easy to miss — a reward moment deserves presence.

- New shared `AchievementBadge` component: bordered, glowing yellow card with an `ACHIEVEMENT_UNLOCKED` kicker and a large (21pt heavy) title
- Victory sequence gains a proper **fourth act**: after the ELO roll, badges pop in one per beat (spring scale + opacity, ~450ms apart), each with a medium haptic tick — a tick-tick rhythm when a run unlocks several at once
- The sudoers interstitial pops the same badge after its punchline (with the haptic), holding a beat longer so it lands
- Reduce Motion: badges appear immediately, no springs

Still minimal: one new ~25-line component, no new state machinery — the sequencing rides the existing `runSequence` tasks.

## Test plan

- [x] Full suite: 63/63 passed (view-only change)
- [ ] Device: win after a debug wipe → badges pop under the ELO ticker; first MASTER → badge in the interstitial

🤖 Generated with [Claude Code](https://claude.com/claude-code)