### PR TITLE
fix: EASY boards can no longer dead-end (generator grading + distribution + breadth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- EASY puzzles could dead-end a player: the difficulty grader's hidden-single scan only checked rows (column/box logic counted as "stuck"), digging ignored clue distribution (boards could be top-dense with a deserted bottom half), and the score counted steps but not breadth. Hidden singles now scan all 27 houses, digging enforces per-difficulty clue floors (EASY keeps ≥3 clues per box and ≥2 per row/column), and EASY boards must be solvable with singles alone while always offering at least two parallel moves; the 40-attempt fallback now prefers boards passing that gate (#37)
 - Achievement unlocks had no visible feedback: the toast raced the victory overlay and could expire unseen behind the matrix rain. Unlocks now render inside the victory sequence itself (`>> UNLOCKED: ...` under the ELO ticker), and the sudoers interstitial types out its own secret-achievement line — the separate toast and its cross-view choreography are gone
 - Pinned `IPHONEOS_DEPLOYMENT_TARGET` back to the literal `17.0` on all targets: Xcode's "Update to recommended settings" had rewritten it to `$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)`, which Xcode Cloud's toolchain resolves to nothing, dropping the deployment target to the SDK floor and failing builds with iOS 16/17 availability errors
 

--- a/SudoSodoku/Algorithms/SudokuGenerator.swift
+++ b/SudoSodoku/Algorithms/SudokuGenerator.swift
@@ -3,12 +3,51 @@ import Foundation
 struct SudokuGenerator {
     static let MAX_RAW_SCORE = 320.0
     static let MIN_RAW_SCORE = 30.0
-    
+
+    /// All 27 houses: 9 rows, 9 columns, 9 boxes.
+    static let allUnits: [[Int]] = {
+        var units: [[Int]] = []
+        for row in 0..<9 { units.append((0..<9).map { row * 9 + $0 }) }
+        for col in 0..<9 { units.append((0..<9).map { $0 * 9 + col }) }
+        for box in 0..<9 {
+            let origin = (box / 3) * 27 + (box % 3) * 3
+            units.append((0..<9).map { origin + ($0 / 3) * 9 + $0 % 3 })
+        }
+        return units
+    }()
+
+    /// Minimum clues that must survive digging per row/column/box, so easier
+    /// boards can't end up with near-empty regions (a top-dense board with a
+    /// deserted bottom half dead-ends a human even when technically solvable).
+    struct ClueFloors {
+        let box: Int
+        let row: Int
+        let column: Int
+    }
+
+    static func clueFloors(for difficulty: Difficulty) -> ClueFloors {
+        switch difficulty {
+        case .easy: return ClueFloors(box: 3, row: 2, column: 2)
+        case .medium: return ClueFloors(box: 2, row: 1, column: 1)
+        case .hard: return ClueFloors(box: 1, row: 0, column: 0)
+        case .master: return ClueFloors(box: 0, row: 0, column: 0)
+        }
+    }
+
     static func generatePuzzle(targetDifficulty: Difficulty) -> ([Int], [Int], Int) {
-        var bestBoard: [Int] = []
-        var bestScore = -1
         let solvedBoard = generateSolvedBoard()
-        
+        let floors = clueFloors(for: targetDifficulty)
+        let targetCenter = Double(targetDifficulty.scoreRange.lowerBound + targetDifficulty.scoreRange.upperBound) / 2.0
+
+        // Best-effort fallbacks, preferring boards that pass the quality gate.
+        var bestQualified: (board: [Int], score: Int)?
+        var bestAny: (board: [Int], score: Int)?
+
+        func isCloser(_ score: Int, than current: (board: [Int], score: Int)?) -> Bool {
+            guard let current else { return true }
+            return abs(Double(score) - targetCenter) < abs(Double(current.score) - targetCenter)
+        }
+
         let maxAttempts = 40
         for _ in 0..<maxAttempts {
             let cluesToKeep: Int
@@ -18,65 +57,95 @@ struct SudokuGenerator {
             case .hard: cluesToKeep = Int.random(in: 24...32)
             case .master: cluesToKeep = Int.random(in: 20...25)
             }
-            
-            let puzzle = digHoles(solvedBoard: solvedBoard, targetClues: cluesToKeep)
-            let rawScore = evaluateDifficulty(puzzle: puzzle)
-            let normalizedScore = normalize(rawScore)
-            
-            if targetDifficulty.scoreRange.contains(normalizedScore) {
+
+            let puzzle = digHoles(solvedBoard: solvedBoard, targetClues: cluesToKeep, floors: floors)
+            let analysis = solveWithSingles(puzzle: puzzle)
+            let normalizedScore = normalize(analysis.rawScore)
+
+            // EASY must be finishable with singles alone and never funnel the
+            // player into a single forced move (endgame excepted).
+            let qualifies = targetDifficulty != .easy || (analysis.solved && analysis.minChoices >= 2)
+
+            if qualifies && targetDifficulty.scoreRange.contains(normalizedScore) {
                 return (puzzle, solvedBoard, normalizedScore)
             }
-            
-            let targetCenter = Double(targetDifficulty.scoreRange.lowerBound + targetDifficulty.scoreRange.upperBound) / 2.0
-            let currentDist = abs(Double(normalizedScore) - targetCenter)
-            let bestDist = bestScore == -1 ? Double.infinity : abs(Double(bestScore) - targetCenter)
-            
-            if bestBoard.isEmpty || currentDist < bestDist {
-                bestBoard = puzzle
-                bestScore = normalizedScore
+            if qualifies && isCloser(normalizedScore, than: bestQualified) {
+                bestQualified = (puzzle, normalizedScore)
+            }
+            if isCloser(normalizedScore, than: bestAny) {
+                bestAny = (puzzle, normalizedScore)
             }
         }
-        return (bestBoard, solvedBoard, bestScore)
+
+        let fallback = bestQualified ?? bestAny ?? (solvedBoard, 0)
+        return (fallback.board, solvedBoard, fallback.score)
     }
-    
+
     static func normalize(_ raw: Int) -> Int {
         let percentage = (Double(raw) - MIN_RAW_SCORE) / (MAX_RAW_SCORE - MIN_RAW_SCORE)
         let score = Int(percentage * 100)
         return max(0, min(100, score))
     }
-    
-    static func evaluateDifficulty(puzzle: [Int]) -> Int {
-        var tempBoard = puzzle
+
+    /// How a singles-only solver (the model of a human on EASY) experiences
+    /// the puzzle: total effort, whether it ever dead-ends, and the narrowest
+    /// count of simultaneously available moves. The last 8 cells are exempt
+    /// from the breadth measure — the endgame is naturally forced.
+    struct SinglesAnalysis {
+        let rawScore: Int
+        let solved: Bool
+        let minChoices: Int
+    }
+
+    static func solveWithSingles(puzzle: [Int]) -> SinglesAnalysis {
+        var board = puzzle
         var score = 0
-        var emptyCells = tempBoard.filter { $0 == 0 }.count
-        
+        var emptyCells = board.filter { $0 == 0 }.count
+        var minChoices = Int.max
+
         while emptyCells > 0 {
-            var progressMade = false
-            for i in 0..<81 {
-                if tempBoard[i] == 0 {
-                    let candidates = getCandidates(board: tempBoard, index: i)
-                    if candidates.count == 1 {
-                        tempBoard[i] = candidates[0]
-                        score += 1
-                        emptyCells -= 1
-                        progressMade = true
-                    }
+            var nakedSingles: [Int] = []
+            for index in 0..<81 where board[index] == 0 {
+                if getCandidates(board: board, index: index).count == 1 {
+                    nakedSingles.append(index)
                 }
             }
-            if progressMade { continue }
-            if let move = findHiddenSingle(board: tempBoard) {
-                tempBoard[move.index] = move.value
-                score += 3
-                emptyCells -= 1
-                progressMade = true
+
+            if !nakedSingles.isEmpty {
+                if emptyCells > 8 { minChoices = min(minChoices, nakedSingles.count) }
+                for index in nakedSingles {
+                    let candidates = getCandidates(board: board, index: index)
+                    guard candidates.count == 1 else { continue }
+                    board[index] = candidates[0]
+                    score += 1
+                    emptyCells -= 1
+                }
+                continue
             }
-            if progressMade { continue }
-            score += (emptyCells * 5)
-            break
+
+            let hidden = hiddenSingles(board: board)
+            if !hidden.isEmpty {
+                if emptyCells > 8 { minChoices = min(minChoices, hidden.count) }
+                for (index, value) in hidden where board[index] == 0 {
+                    board[index] = value
+                    score += 3
+                    emptyCells -= 1
+                }
+                continue
+            }
+
+            // Requires techniques beyond singles.
+            score += emptyCells * 5
+            return SinglesAnalysis(rawScore: score, solved: false, minChoices: minChoices == .max ? 0 : minChoices)
         }
-        return score
+
+        return SinglesAnalysis(rawScore: score, solved: true, minChoices: minChoices == .max ? 9 : minChoices)
     }
-    
+
+    static func evaluateDifficulty(puzzle: [Int]) -> Int {
+        solveWithSingles(puzzle: puzzle).rawScore
+    }
+
     static func getCandidates(board: [Int], index: Int) -> [Int] {
         var candidates: [Int] = []
         let row = index / 9
@@ -88,28 +157,37 @@ struct SudokuGenerator {
         }
         return candidates
     }
-    
+
+    /// First hidden single, scanning all 27 houses. (A row-only scan here
+    /// misgraded puzzles solvable via column/box logic as dead ends — the
+    /// root cause of unfair "easy" boards.)
     static func findHiddenSingle(board: [Int]) -> (index: Int, value: Int)? {
-        for r in 0..<9 {
-            var counts = Array(repeating: 0, count: 10)
-            var positions = Array(repeating: -1, count: 10)
-            for c in 0..<9 {
-                let idx = r * 9 + c
-                if board[idx] == 0 {
-                    let candidates = getCandidates(board: board, index: idx)
-                    for val in candidates {
-                        counts[val] += 1
-                        positions[val] = idx
-                    }
+        hiddenSingles(board: board).first
+    }
+
+    /// Every cell that is the only possible home for some value within one
+    /// of its houses, deduplicated by cell.
+    static func hiddenSingles(board: [Int]) -> [(index: Int, value: Int)] {
+        var results: [(index: Int, value: Int)] = []
+        var claimedCells = Set<Int>()
+
+        for unit in allUnits {
+            var counts = [Int](repeating: 0, count: 10)
+            var positions = [Int](repeating: -1, count: 10)
+            for index in unit where board[index] == 0 {
+                for value in getCandidates(board: board, index: index) {
+                    counts[value] += 1
+                    positions[value] = index
                 }
             }
-            for val in 1...9 {
-                if counts[val] == 1 && positions[val] != -1 {
-                    return (positions[val], val)
+            for value in 1...9 where counts[value] == 1 {
+                let index = positions[value]
+                if claimedCells.insert(index).inserted {
+                    results.append((index, value))
                 }
             }
         }
-        return nil
+        return results
     }
 
     static func generateSolvedBoard() -> [Int] {
@@ -117,7 +195,7 @@ struct SudokuGenerator {
         _ = solve(&board)
         return board
     }
-    
+
     static func solve(_ board: inout [Int]) -> Bool {
         guard let index = board.firstIndex(of: 0) else { return true }
         let numbers = (1...9).shuffled()
@@ -130,7 +208,7 @@ struct SudokuGenerator {
         }
         return false
     }
-    
+
     static func isValid(_ board: [Int], _ num: Int, _ row: Int, _ col: Int) -> Bool {
         for i in 0..<9 {
             if board[row * 9 + i] == num { return false }
@@ -141,42 +219,70 @@ struct SudokuGenerator {
         }
         return true
     }
-    
-    static func digHoles(solvedBoard: [Int], targetClues: Int) -> [Int] {
+
+    static func digHoles(solvedBoard: [Int], targetClues: Int, floors: ClueFloors) -> [Int] {
         var puzzle = solvedBoard
+        var rowClues = [Int](repeating: 9, count: 9)
+        var colClues = [Int](repeating: 9, count: 9)
+        var boxClues = [Int](repeating: 9, count: 9)
         let indices = Array(0..<81).shuffled()
         var holesToDig = 81 - targetClues
+
         for idx in indices {
             if holesToDig <= 0 { break }
+            let row = idx / 9
+            let col = idx % 9
+            let box = (row / 3) * 3 + col / 3
+            guard rowClues[row] > floors.row,
+                  colClues[col] > floors.column,
+                  boxClues[box] > floors.box else { continue }
+
             let backup = puzzle[idx]
             puzzle[idx] = 0
             if countSolutions(board: puzzle, limit: 2) == 1 {
                 holesToDig -= 1
+                rowClues[row] -= 1
+                colClues[col] -= 1
+                boxClues[box] -= 1
             } else {
                 puzzle[idx] = backup
             }
         }
         return puzzle
     }
-    
+
     static func countSolutions(board: [Int], limit: Int) -> Int {
         var copy = board
         var count = 0
         _solveCount(&copy, count: &count, limit: limit)
         return count
     }
-    
+
     static func _solveCount(_ board: inout [Int], count: inout Int, limit: Int) {
         if count >= limit { return }
-        guard let index = board.firstIndex(of: 0) else { count += 1; return }
-        for num in 1...9 {
-            if isValid(board, num, index / 9, index % 9) {
-                board[index] = num
-                _solveCount(&board, count: &count, limit: limit)
-                board[index] = 0
+
+        // MRV: branch on the most constrained cell. Collapses the search tree
+        // on sparse boards, where first-empty branching is pathologically slow.
+        var bestIndex = -1
+        var bestCandidates: [Int] = []
+        for index in 0..<81 where board[index] == 0 {
+            let candidates = getCandidates(board: board, index: index)
+            if candidates.isEmpty { return } // contradiction: dead branch
+            if bestIndex == -1 || candidates.count < bestCandidates.count {
+                bestIndex = index
+                bestCandidates = candidates
+                if bestCandidates.count == 1 { break }
             }
         }
+        guard bestIndex != -1 else {
+            count += 1
+            return
+        }
+
+        for num in bestCandidates {
+            board[bestIndex] = num
+            _solveCount(&board, count: &count, limit: limit)
+        }
+        board[bestIndex] = 0
     }
 }
-
-

--- a/SudoSodokuTests/GeneratorQualityTests.swift
+++ b/SudoSodokuTests/GeneratorQualityTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import SudoSodoku
+
+final class GeneratorQualityTests: XCTestCase {
+
+    // MARK: - Hidden singles beyond rows (regression for the row-only scan)
+
+    func testHiddenSingleDetectedInColumn() {
+        // Column 0 holds every digit except 5, so (0,0) is a hidden single
+        // for 5 in that column. Row 0 has many possible homes for 5, so the
+        // old row-only scan returned nil here and graded the board "stuck".
+        var board = Array(repeating: 0, count: 81)
+        let columnValues = [1, 2, 3, 4, 6, 7, 8, 9]
+        for (offset, value) in columnValues.enumerated() {
+            board[(offset + 1) * 9] = value
+        }
+
+        let move = SudokuGenerator.findHiddenSingle(board: board)
+        XCTAssertEqual(move?.index, 0)
+        XCTAssertEqual(move?.value, 5)
+    }
+
+    // MARK: - EASY quality gate
+
+    func testEasyBoardIsSinglesSolvableWithBreadthAndSpreadClues() {
+        let (puzzle, _, _) = SudokuGenerator.generatePuzzle(targetDifficulty: .easy)
+
+        let analysis = SudokuGenerator.solveWithSingles(puzzle: puzzle)
+        XCTAssertTrue(analysis.solved, "EASY must be finishable with singles alone")
+        XCTAssertGreaterThanOrEqual(analysis.minChoices, 2,
+                                    "EASY must never funnel the player into a single forced move")
+
+        assertFloors(puzzle, box: 3, row: 2, column: 2, label: "EASY")
+    }
+
+    func testMediumBoardRespectsClueFloors() {
+        let (puzzle, _, _) = SudokuGenerator.generatePuzzle(targetDifficulty: .medium)
+        assertFloors(puzzle, box: 2, row: 1, column: 1, label: "MEDIUM")
+    }
+
+    // MARK: - digHoles floor mechanics (no generation loop)
+
+    func testDigHolesNeverDropsBelowFloors() {
+        let solved = SudokuGenerator.generateSolvedBoard()
+        // Aggressive target: floors must win over the clue budget.
+        let puzzle = SudokuGenerator.digHoles(
+            solvedBoard: solved,
+            targetClues: 20,
+            floors: SudokuGenerator.ClueFloors(box: 3, row: 2, column: 2)
+        )
+        assertFloors(puzzle, box: 3, row: 2, column: 2, label: "digHoles")
+        XCTAssertEqual(SudokuGenerator.countSolutions(board: puzzle, limit: 2), 1)
+    }
+
+    // MARK: - Helpers
+
+    private func assertFloors(
+        _ puzzle: [Int], box: Int, row: Int, column: Int, label: String,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
+        for unit in 0..<9 {
+            let rowClues = (0..<9).filter { puzzle[unit * 9 + $0] != 0 }.count
+            XCTAssertGreaterThanOrEqual(rowClues, row, "\(label): row \(unit) too sparse", file: file, line: line)
+
+            let colClues = (0..<9).filter { puzzle[$0 * 9 + unit] != 0 }.count
+            XCTAssertGreaterThanOrEqual(colClues, column, "\(label): column \(unit) too sparse", file: file, line: line)
+
+            let origin = (unit / 3) * 27 + (unit % 3) * 3
+            let boxClues = (0..<9).filter { puzzle[origin + ($0 / 3) * 9 + $0 % 3] != 0 }.count
+            XCTAssertGreaterThanOrEqual(boxClues, box, "\(label): box \(unit) too sparse", file: file, line: line)
+        }
+    }
+}


### PR DESCRIPTION
## Field report

An EASY board stalled Kai for 5+ minutes: clues clustered in the top boxes, bottom half nearly empty (#37).

## Three compounding causes, three fixes

1. **Row-only hidden singles** — `findHiddenSingle` never scanned columns or boxes, so boards solvable by column/box logic graded as "stuck" (+5/cell). Genuine easies got rejected, and after 40 attempts the fallback **silently returned an off-range board still labeled EASY** (the likely culprit board). Now scans all 27 houses (`allUnits`).
2. **No clue distribution** — digging was uniformly random. Now `digHoles` enforces per-difficulty clue floors: EASY keeps ≥3 clues per box and ≥2 per row/column, MEDIUM ≥2/≥1, HARD ≥1 per box, MASTER unconstrained.
3. **Steps counted, breadth ignored** — a single-file forced chain scored the same as a board with many parallel moves. EASY acceptance now requires `solveWithSingles` to finish (no advanced techniques) **and** ≥2 available singles at every step (last 8 cells exempt — endgames are naturally forced). The fallback prefers gate-passing boards.

## Performance

The smarter grader initially made HARD/MASTER generation pathologically slow (fewer boards hit the stuck-heavy score bands → more attempts → `countSolutions` hammered on sparse boards). Fixed by switching the solution counter from first-empty to **MRV branching** with contradiction pruning. Bench harness (5 boards each, macOS):

| | before MRV | after |
|---|---|---|
| EASY | 0.06s | 0.05s (in-range 5/5, singles-solvable 5/5, breadth ≥2, floors hold) |
| MEDIUM | 8.2s (in-range 3/5) | 1.9s (**in-range 5/5**) |
| HARD | 36.6s | 7.5s (~1.5s/board) |
| MASTER | 165.7s | 13.1s (~2.6s/board, hidden behind the breach log) |

Scoring model itself is unchanged (naked +1 / hidden +3 / stuck +5×empties, same bands) — grading is just no longer blind.

## Test plan

- [x] 4 new tests (`GeneratorQualityTests`): column hidden-single regression (old code provably returned nil on the fixture), EASY singles-solvable + breadth ≥2 + floors, MEDIUM floors, `digHoles` floor mechanics vs an aggressive clue budget + uniqueness
- [x] Full suite: 67/67 passed (on a freshly rebuilt simulator — the Xcode beta update had wiped iOS runtimes)
- [x] macOS bench harness: ALL CHECKS PASSED (numbers above)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)