### PR TITLE
fix: WHOAMI stats lag storage by one mutation (willSet read-back)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Profile (WHOAMI) statistics desynced from storage: `@Published` emits on willSet, and the stats refresh read the records back through the singleton — always one mutation behind. Zeros stuck on a fresh launch, numbers survived the debug wipe, and only playing a move "fixed" them. Stats now derive from the emitted value (#41)
 - Achievement unlocks had no visible feedback: the toast raced the victory overlay and could expire unseen behind the matrix rain. Unlocks now render inside the victory sequence itself (`>> UNLOCKED: ...` under the ELO ticker), and the sudoers interstitial types out its own secret-achievement line — the separate toast and its cross-view choreography are gone
 - Pinned `IPHONEOS_DEPLOYMENT_TARGET` back to the literal `17.0` on all targets: Xcode's "Update to recommended settings" had rewritten it to `$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)`, which Xcode Cloud's toolchain resolves to nothing, dropping the deployment target to the SDK floor and failing builds with iOS 16/17 availability errors
 

--- a/SudoSodoku/Managers/StatisticsManager.swift
+++ b/SudoSodoku/Managers/StatisticsManager.swift
@@ -15,51 +15,37 @@ class StatisticsManager: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
 
     init() {
-        refreshData()
+        refresh(with: StorageManager.shared.records)
+        // A @Published publisher emits on *willSet*: when this fires, the
+        // singleton still holds the records from before the change. Stats
+        // must be derived from the emitted value - reading back through
+        // StorageManager here would lag storage by one mutation (zeros on
+        // launch, stale numbers after a wipe).
         StorageManager.shared.$records
-            .sink { [weak self] _ in self?.refreshData() }
+            .sink { [weak self] records in self?.refresh(with: records) }
             .store(in: &cancellables)
     }
 
-    func refreshData() {
-        personalBests = getAllDifficultyBests()
-        overallStats = getOverallStats()
-    }
-
-    func getPersonalBests(for difficulty: Difficulty, limit: Int = 10) -> [GameRecord] {
-        StorageManager.shared.records
-            .filter { $0.difficulty == difficulty.rawValue && $0.isSolved }
-            .sorted { $0.logicalEfficiency > $1.logicalEfficiency }
-            .prefix(limit)
-            .map { $0 }
-    }
-
-    func getBestLogicalEfficiency(for difficulty: Difficulty) -> GameRecord? {
-        StorageManager.shared.records
-            .filter { $0.difficulty == difficulty.rawValue && $0.isSolved }
-            .max { $0.logicalEfficiency < $1.logicalEfficiency }
-    }
-
-    func getAllDifficultyBests() -> [Difficulty: GameRecord] {
+    private func refresh(with records: [GameRecord]) {
         var bests: [Difficulty: GameRecord] = [:]
         for difficulty in Difficulty.allCases {
-            if let best = getPersonalBests(for: difficulty, limit: 1).first {
-                bests[difficulty] = best
-            }
+            bests[difficulty] = records
+                .filter { $0.difficulty == difficulty.rawValue && $0.isSolved }
+                .max { $0.logicalEfficiency < $1.logicalEfficiency }
         }
-        return bests
-    }
+        personalBests = bests
 
-    func getOverallStats() -> OverallStats {
-        let records = StorageManager.shared.records
         let solvedRecords = records.filter(\.isSolved)
-        return OverallStats(
+        overallStats = OverallStats(
             totalGames: records.count,
             solvedGames: solvedRecords.count,
             totalUndos: solvedRecords.reduce(0) { $0 + $1.undoCount },
             bestLogicalEfficiency: solvedRecords.max { $0.logicalEfficiency < $1.logicalEfficiency }?.logicalEfficiency ?? 0
         )
     }
+
+    // The methods below are called from view bodies at render time, after
+    // storage's didSet has completed, so reading the singleton is safe here.
 
     func getDifficultyDistribution() -> [Difficulty: Int] {
         var distribution: [Difficulty: Int] = [:]

--- a/SudoSodokuTests/StatisticsSyncTests.swift
+++ b/SudoSodokuTests/StatisticsSyncTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import SudoSodoku
+
+/// Regression tests for the stats/storage desync: `@Published` emits on
+/// willSet, and the old implementation read the records back through the
+/// singleton — so the WHOAMI numbers always lagged storage by one mutation
+/// (zeros on launch, stale after a wipe).
+final class StatisticsSyncTests: XCTestCase {
+
+    private let currentFileName = "save_data_v4.json"
+
+    override func setUp() {
+        super.setUp()
+        StorageManager.shared.wipeAllData()
+    }
+
+    override func tearDown() {
+        StorageManager.shared.wipeAllData()
+        try? FileManager.default.removeItem(
+            at: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent(currentFileName)
+        )
+        super.tearDown()
+    }
+
+    func testStatsReflectASaveImmediately() {
+        let before = StatisticsManager.shared.overallStats.totalGames
+        XCTAssertEqual(before, 0)
+
+        StorageManager.shared.saveGame(makeRecord(solved: true))
+
+        let stats = StatisticsManager.shared.overallStats
+        XCTAssertEqual(stats.totalGames, 1, "Stats must include the record in the same mutation, not lag by one")
+        XCTAssertEqual(stats.solvedGames, 1)
+    }
+
+    func testStatsReflectAWipeImmediately() {
+        StorageManager.shared.saveGame(makeRecord(solved: true))
+        StorageManager.shared.saveGame(makeRecord(solved: false))
+        XCTAssertEqual(StatisticsManager.shared.overallStats.totalGames, 2)
+
+        StorageManager.shared.wipeAllData()
+
+        XCTAssertEqual(StatisticsManager.shared.overallStats.totalGames, 0,
+                       "The wipe must zero the WHOAMI numbers immediately")
+        XCTAssertEqual(StatisticsManager.shared.overallStats.solvedGames, 0)
+        XCTAssertTrue(StatisticsManager.shared.personalBests.isEmpty)
+    }
+
+    func testStatsReflectADeletionImmediately() {
+        let record = makeRecord(solved: true)
+        StorageManager.shared.saveGame(record)
+        XCTAssertEqual(StatisticsManager.shared.overallStats.totalGames, 1)
+
+        StorageManager.shared.deleteRecord(id: record.id)
+
+        XCTAssertEqual(StatisticsManager.shared.overallStats.totalGames, 0)
+    }
+
+    func testPersonalBestsTrackTheEmittedRecords() {
+        StorageManager.shared.saveGame(makeRecord(solved: true, undoCount: 10))
+        let cleaner = makeRecord(solved: true, undoCount: 0)
+        StorageManager.shared.saveGame(cleaner)
+
+        XCTAssertEqual(StatisticsManager.shared.personalBests[.easy]?.id, cleaner.id,
+                       "Personal best must be recomputed from the just-changed records")
+    }
+
+    // MARK: - Fixtures
+
+    private func makeRecord(solved: Bool, undoCount: Int = 0) -> GameRecord {
+        GameRecord(
+            id: UUID(),
+            startTime: Date(),
+            lastPlayedTime: Date(),
+            difficulty: "EASY",
+            difficultyIndex: 10,
+            initialBoard: Array(repeating: 0, count: 81),
+            solution: Array(repeating: 1, count: 81),
+            playerBoard: Array(repeating: 0, count: 81),
+            playerNotes: nil,
+            isSolved: solved,
+            ratingChange: nil,
+            undoCount: undoCount
+        )
+    }
+}


### PR DESCRIPTION
## Symptoms (field report, #41)

- Fresh launch / rebuild: GAMES PLAYED and PUZZLES SOLVED show **0** despite intact archives
- Playing one game "fixes" the numbers
- The debug data wipe leaves the profile numbers **unchanged**
- The archive itself is always correct

## Root cause — one line of timing

`StatisticsManager` subscribes to `StorageManager.shared.$records`, but a `@Published` publisher emits on **willSet**. The refresh ignored the emitted value and re-read `StorageManager.shared.records` — which at that instant still holds the **pre-change** array. Stats therefore always lag storage by exactly one mutation:

| flow | records transition | refresh saw | result |
|---|---|---|---|
| launch (async load) | `[] → 50 records` | `[]` | zeros stick |
| gameplay | dozens of saves | previous save | lag shrinks to the last move → "looks fixed" |
| debug wipe | `50 → []` | the old 50 | numbers survive the wipe |

## Fix

Consume the emitted records inside the sink; never read the singleton back during the subscription. Query methods used from view bodies (render runs after didSet) keep reading the singleton safely — noted in a comment. Three dead query methods deleted.

## Test plan

- [x] 4 regression tests (`StatisticsSyncTests`) asserting *immediate* consistency after save / delete / wipe, plus personal-best recomputation — each fails on the old implementation by exactly one lagged mutation
- [x] Full suite: 67/67 passed

Independent of the open generator PRs (#38/#40) — no shared files, mergeable in any order.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)