### PR TITLE
chore: cut v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Nothing yet._
+
+---
+
+## [2.0.0] - 2026-07-08
+
+### 🚀 sudo solve — root access for logical purists
+
+v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a full terminal fantasy with a real competitive ladder. Game Center leaderboards and achievements go live, every puzzle now reads as hand-crafted, and the whole game got a feel pass — haptics, signature moments, and accessibility discipline throughout.
+
+**Requirements:** iOS 17.0+, iPhone only. Internet optional (Game Center).
+
 ### Added
 
 - Completion time tracking: play clock accumulates active time per game, pauses in the background and freezes on victory; terminal-style `T+MM:SS` timer in the game header (toggleable via the game menu), duration shown on victory, in archive rows, and in personal bests (#4)

--- a/RELEASE_NOTES_v2.0.0.md
+++ b/RELEASE_NOTES_v2.0.0.md
@@ -1,0 +1,38 @@
+# SudoSodoku v2.0.0
+
+```
+$ sudo solve
+> root access granted.
+```
+
+**sudo solve — root access for logical purists.**
+
+v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a full terminal fantasy with a real competitive ladder.
+
+## The Ladder goes live 🏆
+
+- **Game Center leaderboards**: a global ELO ranking plus fastest-time boards for every difficulty. Scores are performance — solve time and rating — never spending.
+- **Twelve achievements**, from `HELLO_WORLD` to `THE_ARCHITECT`, including one secret. Unlocks are celebrated inside the victory sequence with glowing badges.
+
+## Every puzzle now reads as hand-crafted ✍️
+
+- Clue patterns follow varied aesthetic styles — rotational, mirror, diagonal, or deliberately free — like a well-edited puzzle book.
+- Every difficulty has a technique identity: EASY always offers parallel simple moves and can never dead-end you; HARD is designed around a fair intermediate "aha" and never requires guessing; MASTER resists intermediate techniques entirely.
+- Generation stays instant (≤10ms) behind the new breach-log loading screen.
+
+## The feel pass 🎛️
+
+- A semantic haptic vocabulary: mechanical key-press placements, error notifications, unit-completion pulses, and a custom victory rumble.
+- Signature moments: the typewriter breach log, a three-act victory sequence with real matrix rain and an ELO ticker, phosphor pulses on completed units, a quiet streak counter — and a one-time surprise for your first MASTER game.
+- An optional play clock that only counts active time; personal bests and archives show durations.
+- Every animation respects Reduce Motion. Sounds are never forced on.
+
+## Fixed
+
+- EASY boards can no longer stall you: the grader now understands column/box logic, clue distribution is guaranteed, and every step offers at least two ways forward.
+- Profile statistics stay in lockstep with your archive (previously they lagged by one change).
+
+---
+
+**Requirements:** iOS 17.0+, iPhone only. Internet optional (Game Center).
+Full details in [CHANGELOG.md](CHANGELOG.md).

--- a/SudoSodoku.xcodeproj/project.pbxproj
+++ b/SudoSodoku.xcodeproj/project.pbxproj
@@ -341,7 +341,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.kaichen.sudoku.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -380,7 +380,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.kaichen.sudoku.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -406,7 +406,7 @@
 				DEVELOPMENT_TEAM = 4Q3P7THMVS;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.kaichen.sudoku.app.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -432,7 +432,7 @@
 				DEVELOPMENT_TEAM = 4Q3P7THMVS;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.kaichen.sudoku.app.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/SudoSodoku/Utils/AppConstants.swift
+++ b/SudoSodoku/Utils/AppConstants.swift
@@ -18,7 +18,7 @@ enum AppConstants {
     }
 
     static var marketingVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "2.0.0"
     }
 
     static func leaderboardID(for difficulty: String) -> String {


### PR DESCRIPTION
## Summary

The repo side of the v2.0.0 submission (#21):

- `MARKETING_VERSION` → **2.0.0** on all targets (app Debug/Release + tests)
- CHANGELOG: `[Unreleased]` cut into **`[2.0.0] - 2026-07-08`** with a release intro; fresh empty Unreleased section on top
- `RELEASE_NOTES_v2.0.0.md` (repo convention, mirrors v1.0.0's)
- `AppConstants.marketingVersion` fallback string updated

Scope note: C-tier ambience issues #18–#20 were moved out of the milestone (first-cut per plan + minimalism principle); the milestone now contains only #21 itself.

The ASC-side steps (screenshots, listing, privacy label, TestFlight, submission) are documented as a step-by-step guide on #21.

## Test plan

- [x] Full suite on the release branch: TEST SUCCEEDED
- [x] `KERNEL_V2.0.0` will now show on the landing screen (version read from bundle)

Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)