### PR TITLE
fix: first-launch white screen + Swift 6 warning (ship blockers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a fu
 
 ### Fixed
 
+- First launch after install could hang on a white screen: Game Center's login view was force-presented over the first frame and could fail to load (GameOverlayUI proxy errors), stalling fullscreen until the app was killed. The login UI is never presented at launch anymore — players start as guests and sign in from the leaderboard screen or Settings, which also matches the zero-noise philosophy
+- Swift 6 concurrency warning in achievement reporting: the Sendable completion captured a mutable weak `self`; the retry path now routes through the shared instance with no self capture
 - Profile (WHOAMI) statistics desynced from storage: `@Published` emits on willSet, and the stats refresh read the records back through the singleton — always one mutation behind. Zeros stuck on a fresh launch, numbers survived the debug wipe, and only playing a move "fixed" them. Stats now derive from the emitted value (#41)
 - Achievement unlocks had no visible feedback: the toast raced the victory overlay and could expire unseen behind the matrix rain. Unlocks now render inside the victory sequence itself (`>> UNLOCKED: ...` under the ELO ticker), and the sudoers interstitial types out its own secret-achievement line — the separate toast and its cross-view choreography are gone
 - Pinned `IPHONEOS_DEPLOYMENT_TARGET` back to the literal `17.0` on all targets: Xcode's "Update to recommended settings" had rewritten it to `$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)`, which Xcode Cloud's toolchain resolves to nothing, dropping the deployment target to the SDK floor and failing builds with iOS 16/17 availability errors

--- a/SudoSodoku/Managers/AchievementManager.swift
+++ b/SudoSodoku/Managers/AchievementManager.swift
@@ -87,9 +87,12 @@ final class AchievementManager: ObservableObject {
             gk.showsCompletionBanner = false // the terminal toast is ours
             return gk
         }
-        GKAchievement.report(reports) { [weak self] error in
-            if error != nil {
-                Task { @MainActor in self?.queueForLater(achievements) }
+        // No self capture: a weak `self` is a mutable var, and referencing
+        // it inside the Sendable completion is an error in Swift 6.
+        GKAchievement.report(reports) { error in
+            guard error != nil else { return }
+            Task { @MainActor in
+                AchievementManager.shared.queueForLater(achievements)
             }
         }
     }

--- a/SudoSodoku/Managers/GameCenterManager.swift
+++ b/SudoSodoku/Managers/GameCenterManager.swift
@@ -21,10 +21,16 @@ class GameCenterManager: NSObject, ObservableObject {
             Task { @MainActor in
                 guard let self else { return }
 
-                if let viewController,
-                   let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                   let rootViewController = windowScene.windows.first?.rootViewController {
-                    rootViewController.present(viewController, animated: true)
+                // Never present Game Center's login UI at launch. Signing in
+                // is optional (pure logic, zero noise), and presenting over
+                // the first frame caused the first-launch white hang: the
+                // auth overlay could fail to load (GameOverlayUI proxy
+                // errors) and stall fullscreen. Guests sign in from the
+                // leaderboard screen's access point or Settings > Games.
+                if viewController != nil {
+                    self.isAuthenticated = false
+                    self.playerName = "Guest"
+                    self.playerPhoto = nil
                     return
                 }
 


### PR DESCRIPTION
## 1. First-launch white hang

**Symptom:** fresh install → launch → long white screen; kill + relaunch works.

**Root cause:** `authenticateUser()` force-presented Game Center's login view controller the moment GameKit offered it — right over the first frame. Console showed `Failed to create GameOverlayUI Authentication Remote Proxy`: the auth overlay itself failed to load, leaving a stalled fullscreen white sheet. On relaunch GameKit doesn't re-offer the view controller, so it "worked".

**Fix:** never present the login UI at launch. If GameKit offers a view controller, the player silently stays a guest — the leaderboard screen's `AUTH_REQUIRED` notice, its `GKAccessPoint`, and Settings > Games are the sign-in paths. This is also what the product philosophy (pure logic, zero noise) demanded: no Apple login sheet in your face on first open.

**Verified end-to-end:** fresh `simctl uninstall` → install → launch on iPhone 17 Pro Max sim renders the dark landing immediately (`user: guest`, `KERNEL_V2.0.0` visible) — screenshot in the session log.

## 2. Swift 6 concurrency warning (the Xcode "2" badge)

`AchievementManager.report`'s Sendable completion captured a mutable weak `self` (`[weak self]` + `self?.` inside a `Task`) — an error in Swift 6 language mode. The retry path now routes through `AchievementManager.shared` inside a `@MainActor` task with no self capture. Build is back to **zero warnings**.

## Test plan

- [x] Zero concurrency warnings on a clean build
- [x] Full suite: TEST SUCCEEDED
- [x] Fresh-install first-launch E2E in simulator: instant dark landing, no white hang
- [ ] Kai: same fresh-install check on device before archiving

Refs #21 — merge before archiving the 2.0.0 build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)