### PR TITLE
fix: hidden achievement leaked its title on the profile wall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a fu
 
 ### Fixed
 
+- The secret INCIDENT_REPORTED achievement wasn't actually secret: the profile wall listed its title with only the description masked. Hidden achievements are now entirely absent from the wall until earned, matching Game Center's Hidden semantics
 - Profile (WHOAMI) statistics desynced from storage: `@Published` emits on willSet, and the stats refresh read the records back through the singleton — always one mutation behind. Zeros stuck on a fresh launch, numbers survived the debug wipe, and only playing a move "fixed" them. Stats now derive from the emitted value (#41)
 - Achievement unlocks had no visible feedback: the toast raced the victory overlay and could expire unseen behind the matrix rain. Unlocks now render inside the victory sequence itself (`>> UNLOCKED: ...` under the ELO ticker), and the sudoers interstitial types out its own secret-achievement line — the separate toast and its cross-view choreography are gone
 - Pinned `IPHONEOS_DEPLOYMENT_TARGET` back to the literal `17.0` on all targets: Xcode's "Update to recommended settings" had rewritten it to `$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)`, which Xcode Cloud's toolchain resolves to nothing, dropping the deployment target to the SDK floor and failing builds with iOS 16/17 availability errors

--- a/SudoSodoku/Models/Achievement.swift
+++ b/SudoSodoku/Models/Achievement.swift
@@ -53,8 +53,15 @@ enum Achievement: String, CaseIterable, Identifiable {
         }
     }
 
-    /// Secret achievements show masked details until unlocked.
+    /// Secret achievements don't exist publicly until earned.
     var isSecret: Bool { self == .incidentReported }
+
+    /// The profile wall's list: secrets stay entirely invisible until
+    /// unlocked (even the title is a spoiler), matching Game Center's
+    /// Hidden semantics.
+    static func wallList(isUnlocked: (Achievement) -> Bool) -> [Achievement] {
+        allCases.filter { !$0.isSecret || isUnlocked($0) }
+    }
 }
 
 /// Everything a victory needs to be judged against the achievement list.

--- a/SudoSodoku/Views/UserProfileView.swift
+++ b/SudoSodoku/Views/UserProfileView.swift
@@ -55,7 +55,7 @@ struct UserProfileView: View {
 
                     VStack(alignment: .leading, spacing: 12) {
                         Text("ACHIEVEMENTS:").font(.system(size: 14, weight: .bold, design: .monospaced)).foregroundColor(.gray)
-                        ForEach(Achievement.allCases) { achievement in
+                        ForEach(Achievement.wallList(isUnlocked: achievements.isUnlocked)) { achievement in
                             achievementRow(achievement)
                         }
                     }.padding().background(Color.white.opacity(0.05)).cornerRadius(12).padding(.horizontal)
@@ -122,7 +122,7 @@ struct UserProfileView: View {
                 Text(achievement.title)
                     .font(.system(size: 13, weight: .bold, design: .monospaced))
                     .foregroundColor(unlocked ? .white : .gray)
-                Text(achievement.isSecret && !unlocked ? "????????" : achievement.detail)
+                Text(achievement.detail)
                     .font(.system(size: 10, design: .monospaced))
                     .foregroundColor(.gray.opacity(0.8))
             }

--- a/SudoSodokuTests/AchievementManagerTests.swift
+++ b/SudoSodokuTests/AchievementManagerTests.swift
@@ -61,6 +61,17 @@ final class AchievementManagerTests: XCTestCase {
         XCTAssertEqual(defaults.stringArray(forKey: "unlockedAchievements")?.count, 1)
     }
 
+    func testSecretAchievementsAreInvisibleOnTheWallUntilUnlocked() {
+        let locked = Achievement.wallList(isUnlocked: { _ in false })
+        XCTAssertFalse(locked.contains(.incidentReported),
+                       "A hidden achievement must not exist on the wall - its title alone is a spoiler")
+        XCTAssertEqual(locked.count, Achievement.allCases.count - 1)
+
+        let unlocked = Achievement.wallList(isUnlocked: { $0 == .incidentReported })
+        XCTAssertTrue(unlocked.contains(.incidentReported), "Once earned, the secret joins the wall")
+        XCTAssertEqual(unlocked.count, Achievement.allCases.count)
+    }
+
     func testIncidentReportedIsAOneShotEasterEgg() {
         XCTAssertEqual(manager.unlockIncidentReported(), [.incidentReported])
         XCTAssertTrue(manager.isUnlocked(.incidentReported))


### PR DESCRIPTION
## Bug

The secret `INCIDENT_REPORTED` achievement was listed on the WHOAMI achievement wall with its **title visible** and only the description masked as `????????` — the title alone spoils that a secret exists and hints at the sudoers joke. Effectively not hidden at all.

## Fix

- New pure helper `Achievement.wallList(isUnlocked:)`: secrets are **entirely absent** from the wall until earned, then join it with full title + description — matching Game Center's Hidden semantics (invisible until unlocked)
- The `????????` masking is deleted: locked secrets never render, so there's nothing to mask

## Test plan

- [x] New test: locked → wall has 11 entries without the secret; unlocked → 12 with it
- [x] Full suite: TEST SUCCEEDED

Refs #21 — small, independent of #44; both should merge before archiving 2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)