### PR TITLE
feat: honest statistics — no fail state, no win rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a fu
 
 ### Changed
 
+- Statistics tell the truth for a no-fail game: WIN_RATE is gone (boards are only finished or unfinished — abandoning isn't losing), BEST_EFF is demoted from the headline (it contradicted the fearless-undo philosophy); SYSTEM_OVERVIEW now shows SOLVED / ELO / FASTEST / HARDEST, and a personal best is the fastest solve (efficiency stays as per-record detail) (#46)
 - Puzzles now read as hand-crafted: each board picks an aesthetic clue-pattern style at random (180° rotational, horizontal/vertical mirror, diagonal, anti-diagonal, or deliberately free — hand-made collections vary, symmetry is common but not universal), and every difficulty has a technique identity enforced at generation — EASY solves with singles and always offers parallel moves, MEDIUM never demands more than locked candidates / naked pairs, HARD is designed around a required intermediate "aha" (and never needs more — no guessing), MASTER resists intermediate techniques entirely (#39)
 - Leaderboard submissions previously sent the puzzle difficulty index (0-100), which ranked players by generation luck; scores are now actual performance — solve time per difficulty, ELO on the global board (#11)
 - Set minimum deployment target to iOS 17.0 (aligned project and target settings)

--- a/SudoSodoku/Managers/StatisticsManager.swift
+++ b/SudoSodoku/Managers/StatisticsManager.swift
@@ -8,8 +8,8 @@ class StatisticsManager: ObservableObject {
     @Published var overallStats: OverallStats = OverallStats(
         totalGames: 0,
         solvedGames: 0,
-        totalUndos: 0,
-        bestLogicalEfficiency: 0
+        fastestSolve: nil,
+        hardestSolved: nil
     )
 
     private var cancellables = Set<AnyCancellable>()
@@ -27,20 +27,25 @@ class StatisticsManager: ObservableObject {
     }
 
     private func refresh(with records: [GameRecord]) {
+        // A personal best is the fastest timed solve; records from before
+        // time tracking (duration 0) fall back to the most efficient solve.
         var bests: [Difficulty: GameRecord] = [:]
         for difficulty in Difficulty.allCases {
-            bests[difficulty] = records
-                .filter { $0.difficulty == difficulty.rawValue && $0.isSolved }
-                .max { $0.logicalEfficiency < $1.logicalEfficiency }
+            let solved = records.filter { $0.difficulty == difficulty.rawValue && $0.isSolved }
+            bests[difficulty] = solved
+                .filter { $0.playDuration > 0 }
+                .min { $0.playDuration < $1.playDuration }
+                ?? solved.max { $0.logicalEfficiency < $1.logicalEfficiency }
         }
         personalBests = bests
 
         let solvedRecords = records.filter(\.isSolved)
+        let solvedDifficulties = Set(solvedRecords.compactMap { Difficulty(rawValue: $0.difficulty) })
         overallStats = OverallStats(
             totalGames: records.count,
             solvedGames: solvedRecords.count,
-            totalUndos: solvedRecords.reduce(0) { $0 + $1.undoCount },
-            bestLogicalEfficiency: solvedRecords.max { $0.logicalEfficiency < $1.logicalEfficiency }?.logicalEfficiency ?? 0
+            fastestSolve: solvedRecords.map(\.playDuration).filter { $0 > 0 }.min(),
+            hardestSolved: Difficulty.allCases.last { solvedDifficulties.contains($0) }
         )
     }
 

--- a/SudoSodoku/Models/OverallStats.swift
+++ b/SudoSodoku/Models/OverallStats.swift
@@ -1,18 +1,13 @@
 import Foundation
 
+/// Headline statistics. A no-fail puzzle game has no "win rate" — boards are
+/// only finished or unfinished — so the honest measures are volume (solved),
+/// speed (fastest solve), and depth (hardest tier solved). Rating lives in
+/// StorageManager. totalGames counts every session and belongs to the
+/// archive-flavored surfaces (WHOAMI), never to a ratio.
 struct OverallStats {
     let totalGames: Int
     let solvedGames: Int
-    let totalUndos: Int
-    let bestLogicalEfficiency: Int
-
-    var winRate: Double {
-        guard totalGames > 0 else { return 0 }
-        return Double(solvedGames) / Double(totalGames)
-    }
-
-    var averageUndosPerGame: Double {
-        guard solvedGames > 0 else { return 0 }
-        return Double(totalUndos) / Double(solvedGames)
-    }
+    let fastestSolve: TimeInterval?
+    let hardestSolved: Difficulty?
 }

--- a/SudoSodoku/Views/Components/PersonalBestRow.swift
+++ b/SudoSodoku/Views/Components/PersonalBestRow.swift
@@ -31,30 +31,21 @@ struct PersonalBestRow: View {
                     HStack {
                         Image(systemName: "chart.line.uptrend.xyaxis")
                             .font(.system(size: 10))
-                            .foregroundColor(.green)
+                            .foregroundColor(LogicalEfficiencyStyle.color(for: record.logicalEfficiency))
                         Text("QUALITY: \(record.logicalQuality)")
                             .font(.system(size: 10, design: .monospaced))
                             .foregroundColor(.white)
-                    }
-                    if record.playDuration > 0 {
-                        HStack {
-                            Image(systemName: "stopwatch")
-                                .font(.system(size: 10))
-                                .foregroundColor(.green)
-                            Text("TIME: \(DateFormatting.playClock(record.playDuration))")
-                                .font(.system(size: 10, design: .monospaced))
-                                .foregroundColor(.white)
-                        }
                     }
                 }
 
                 Spacer()
 
+                // A personal best is the fastest solve; time is the headline.
                 VStack(spacing: 2) {
-                    Text("\(record.logicalEfficiency)")
+                    Text(record.playDuration > 0 ? DateFormatting.playClock(record.playDuration) : "--")
                         .font(.system(size: 14, weight: .bold, design: .monospaced))
-                        .foregroundColor(LogicalEfficiencyStyle.color(for: record.logicalEfficiency))
-                    Text("EFFICIENCY")
+                        .foregroundColor(.green)
+                    Text("BEST_TIME")
                         .font(.system(size: 8, design: .monospaced))
                         .foregroundColor(.gray)
                 }

--- a/SudoSodoku/Views/StatsView.swift
+++ b/SudoSodoku/Views/StatsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct StatsView: View {
     @ObservedObject private var stats = StatisticsManager.shared
+    @ObservedObject private var storage = StorageManager.shared
 
     var body: some View {
         ZStack {
@@ -9,11 +10,21 @@ struct StatsView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
                     sectionHeader("SYSTEM_OVERVIEW:")
+                    // No fail state means no "win rate": the honest headline
+                    // numbers are volume, rating, speed, and depth.
                     LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
-                        StatCard(title: "TOTAL_GAMES", value: "\(stats.overallStats.totalGames)", icon: "gamecontroller")
                         StatCard(title: "SOLVED", value: "\(stats.overallStats.solvedGames)", icon: "checkmark.seal")
-                        StatCard(title: "WIN_RATE", value: winRateString, icon: "percent")
-                        StatCard(title: "BEST_EFF", value: "\(stats.overallStats.bestLogicalEfficiency)", icon: "bolt")
+                        StatCard(title: "ELO", value: "\(storage.userRating)", icon: "bolt.shield")
+                        StatCard(
+                            title: "FASTEST",
+                            value: stats.overallStats.fastestSolve.map(DateFormatting.playClock) ?? "--",
+                            icon: "stopwatch"
+                        )
+                        StatCard(
+                            title: "HARDEST",
+                            value: stats.overallStats.hardestSolved?.rawValue ?? "--",
+                            icon: "flame"
+                        )
                     }
 
                     sectionHeader("PERSONAL_BEST_RECORDS:")
@@ -105,7 +116,4 @@ struct StatsView: View {
         .cornerRadius(8)
     }
 
-    private var winRateString: String {
-        String(format: "%.0f%%", stats.overallStats.winRate * 100)
-    }
 }

--- a/SudoSodokuTests/StatisticsSyncTests.swift
+++ b/SudoSodokuTests/StatisticsSyncTests.swift
@@ -66,14 +66,47 @@ final class StatisticsSyncTests: XCTestCase {
                        "Personal best must be recomputed from the just-changed records")
     }
 
+    // MARK: - Honest headline metrics (#46)
+
+    func testFastestAndHardestAggregation() {
+        StorageManager.shared.saveGame(makeRecord(solved: true, difficulty: .easy, duration: 300))
+        StorageManager.shared.saveGame(makeRecord(solved: true, difficulty: .hard, duration: 900))
+        StorageManager.shared.saveGame(makeRecord(solved: false, difficulty: .master, duration: 50))
+
+        let stats = StatisticsManager.shared.overallStats
+        XCTAssertEqual(stats.fastestSolve, 300, "Fastest counts solved boards only")
+        XCTAssertEqual(stats.hardestSolved, .hard, "Unsolved MASTER must not count as depth")
+    }
+
+    func testLegacyZeroDurationNeverWinsFastest() {
+        StorageManager.shared.saveGame(makeRecord(solved: true, duration: 0))
+        XCTAssertNil(StatisticsManager.shared.overallStats.fastestSolve,
+                     "Records from before time tracking must not claim a 0s fastest")
+    }
+
+    func testPersonalBestIsTheFastestSolveNotTheMostEfficient() {
+        let efficient = makeRecord(solved: true, undoCount: 0, duration: 800)
+        let fast = makeRecord(solved: true, undoCount: 20, duration: 200)
+        StorageManager.shared.saveGame(efficient)
+        StorageManager.shared.saveGame(fast)
+
+        XCTAssertEqual(StatisticsManager.shared.personalBests[.easy]?.id, fast.id,
+                       "Speed defines the personal best; efficiency is a per-record detail")
+    }
+
     // MARK: - Fixtures
 
-    private func makeRecord(solved: Bool, undoCount: Int = 0) -> GameRecord {
+    private func makeRecord(
+        solved: Bool,
+        undoCount: Int = 0,
+        difficulty: Difficulty = .easy,
+        duration: TimeInterval = 0
+    ) -> GameRecord {
         GameRecord(
             id: UUID(),
             startTime: Date(),
             lastPlayedTime: Date(),
-            difficulty: "EASY",
+            difficulty: difficulty.rawValue,
             difficultyIndex: 10,
             initialBoard: Array(repeating: 0, count: 81),
             solution: Array(repeating: 1, count: 81),
@@ -81,7 +114,8 @@ final class StatisticsSyncTests: XCTestCase {
             playerNotes: nil,
             isSolved: solved,
             ratingChange: nil,
-            undoCount: undoCount
+            undoCount: undoCount,
+            playDuration: duration
         )
     }
 }


### PR DESCRIPTION
## Why (field feedback, #46)

This game has no fail state: a board is finished or unfinished, and abandoning isn't losing. So `WIN_RATE = solved/total` measured the inverse of your abandonment rate (the denominator includes every auto-saved board you glanced at), punishing harmless exploration. And `BEST_EFF` (1000 − 10×undos) contradicted our own product copy — we advertise undo as *fearless experimentation*, then dock a headline metric for using it.

## The honest metrics

| tile | was | now |
|---|---|---|
| 1 | TOTAL_GAMES | **SOLVED** (the real count) |
| 2 | SOLVED | **ELO** (the skill number, finally on the stats page) |
| 3 | WIN_RATE ❌ | **FASTEST** (best solve time — same measure as the leaderboards) |
| 4 | BEST_EFF ❌ | **HARDEST** (highest tier solved) |

- Personal bests are now the **fastest timed solve** per difficulty (`BEST_TIME` headline), with an efficiency fallback for pre-time-tracking records; efficiency/quality stay as per-record detail lines
- One metric language across stats, leaderboards, and the OVERCLOCKED achievement
- TOTAL_GAMES survives where sessions belong: WHOAMI tiles and the archive
- Display-layer only — no save format changes

## Test plan

- [x] 3 new tests: fastest/hardest aggregation (unsolved MASTER doesn't count as depth), legacy 0-duration can't claim fastest, fastest beats most-efficient for personal best
- [x] Full suite: TEST SUCCEEDED

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)