### PR TITLE
feat: accumulating command-line navigation across the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed
+
+- Every screen entered from the landing page now reads as one continuous, accumulating shell command instead of separate button taps: picking `breach`, `archives`, `stats`, or `whoami` types the subcommand into the prompt before navigating, and the destination screen echoes the full command (e.g. `sudo sodoku breach --easy`) it was reached with (#47)
+- Mode selection's tab-completion menu is pushed further down the screen instead of sitting directly under the prompt (#47)
 
 ---
 

--- a/SudoSodoku/Views/ArchiveView.swift
+++ b/SudoSodoku/Views/ArchiveView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct ArchiveView: View {
+    var commandPrefix: String = "sudo sodoku archives"
+
     @ObservedObject var storage = StorageManager.shared
     @State private var selectedRecordForAction: GameRecord?
     @State private var showActionSheet = false
@@ -17,6 +19,8 @@ struct ArchiveView: View {
         ZStack {
             TerminalBackground()
             VStack(alignment: .leading) {
+                ExecutedCommandLine(command: commandPrefix)
+                    .padding(.leading).padding(.trailing).padding(.top)
                 HStack {
                     Text(filterMode == .favorites ? "FAVORITES:" : "USER_LOGS:")
                         .font(.system(size: 16, weight: .bold, design: .monospaced)).foregroundColor(.gray)

--- a/SudoSodoku/Views/Components/ExecutedCommandLine.swift
+++ b/SudoSodoku/Views/Components/ExecutedCommandLine.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/// Static readout of a command that already "executed" — the terminal
+/// breadcrumb a screen was navigated in with, echoed at the top so the
+/// whole session still reads as one continuous shell trace.
+struct ExecutedCommandLine: View {
+    let command: String
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Text("root@ios:~$ ").foregroundColor(.green)
+            Text(command).foregroundColor(.white)
+        }
+        .font(.system(size: 14, weight: .bold, design: .monospaced))
+    }
+}

--- a/SudoSodoku/Views/Components/TerminalCommandComposer.swift
+++ b/SudoSodoku/Views/Components/TerminalCommandComposer.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+/// One selectable line in a `TerminalCommandComposer`'s tab-completion menu.
+struct CommandOption: Identifiable {
+    let id: String
+    /// Both the row's headline and the text typed into the command line when picked.
+    let label: String
+    let detail: String
+    let color: Color
+}
+
+/// A live terminal prompt whose command line "types itself" from a
+/// tab-completion menu: picking an option animates it into the command,
+/// the command "executes", and `onExecute` hands the pick back to the
+/// caller (typically to navigate onward with the composed command as the
+/// next screen's prefix). Shared by every screen that wants navigation to
+/// read as one continuous, accumulating shell session instead of taps.
+struct TerminalCommandComposer<Hero: View>: View {
+    let awaitingComment: String
+    let baseCommand: String
+    let completionComment: String
+    let options: [CommandOption]
+    let hint: String?
+    let onExecute: (CommandOption) -> Void
+    @ViewBuilder var hero: () -> Hero
+
+    @State private var typedSuffix = ""
+    @State private var pickedOption: CommandOption?
+    @State private var isComposing = false
+    @State private var cursorVisible = true
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            commandSection
+            hero()
+            Spacer()
+            completionSection
+            Spacer()
+            if let hint {
+                Text(hint)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(.gray.opacity(0.6))
+                    .padding(.bottom, 12)
+            }
+        }
+        .padding(.horizontal)
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
+                cursorVisible = false
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var commandSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(awaitingComment)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(.gray)
+            HStack(spacing: 0) {
+                Text("root@ios:~$ ").foregroundColor(.green)
+                Text(baseCommand + " ").foregroundColor(.white)
+                Text(typedSuffix).foregroundColor(pickedOption?.color ?? .green)
+                Text("_")
+                    .foregroundColor(.green)
+                    .opacity(cursorVisible ? 1 : 0)
+            }
+            .font(.system(size: 17, weight: .bold, design: .monospaced))
+        }
+        .padding(.top, 24)
+    }
+
+    private var completionSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(completionComment)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(.gray)
+            ForEach(options) { option in
+                completionRow(option)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func completionRow(_ option: CommandOption) -> some View {
+        let isPicked = pickedOption?.id == option.id
+        Button(action: { pick(option) }) {
+            HStack {
+                VStack(alignment: .leading) {
+                    Text(option.label)
+                        .font(.system(size: 20, weight: .bold, design: .monospaced))
+                        .foregroundColor(option.color)
+                    Text(option.detail)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundColor(.gray)
+                }
+                Spacer()
+                Image(systemName: "return")
+                    .foregroundColor(option.color.opacity(isPicked ? 1 : 0.45))
+            }
+            .padding()
+            .background(isPicked ? option.color.opacity(0.12) : Color.black.opacity(0.5))
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(option.color.opacity(isPicked ? 1 : 0.5), lineWidth: 1)
+            )
+        }
+        .disabled(isComposing)
+    }
+
+    // MARK: - Composing
+
+    private func pick(_ option: CommandOption) {
+        guard !isComposing else { return }
+        isComposing = true
+        pickedOption = option
+        HapticManager.shared.noteModeToggled()
+
+        let text = option.label
+        Task {
+            if reduceMotion {
+                typedSuffix = text
+                try? await Task.sleep(for: .milliseconds(250))
+            } else {
+                for count in 1...text.count {
+                    typedSuffix = String(text.prefix(count))
+                    HapticManager.shared.noteToggled()
+                    try? await Task.sleep(for: .milliseconds(45))
+                }
+                try? await Task.sleep(for: .milliseconds(280))
+            }
+            HapticManager.shared.digitPlaced() // return key
+            onExecute(option)
+        }
+    }
+}

--- a/SudoSodoku/Views/LandingView.swift
+++ b/SudoSodoku/Views/LandingView.swift
@@ -1,89 +1,102 @@
 import SwiftUI
 
+private enum LandingTarget: String, Identifiable {
+    case breach, archives, stats, whoami
+    var id: String { rawValue }
+}
+
 struct LandingView: View {
-    @State private var cursorOpacity = 1.0
     @State private var glowStrength = 1.0
+    @State private var launchTarget: LandingTarget?
+    @State private var composerKey = UUID()
     @ObservedObject var gcManager = GameCenterManager.shared
-    
+
     var body: some View {
         ZStack {
             TerminalBackground()
-            
+
             VStack {
-                HStack {
-                    if gcManager.isAuthenticated {
-                        if let photo = gcManager.playerPhoto {
-                            photo.resizable().scaledToFit().frame(width: 30, height: 30).clipShape(Circle()).overlay(Circle().stroke(Color.green, lineWidth: 1))
-                        } else {
-                            Image(systemName: "person.circle.fill").font(.system(size: 30)).foregroundColor(.green)
-                        }
-                        Text("user: \(gcManager.playerName)").font(.system(size: 14, design: .monospaced)).foregroundColor(.green)
-                    } else {
-                        Image(systemName: "person.circle").font(.system(size: 30)).foregroundColor(.gray)
-                        Text("user: guest").font(.system(size: 14, design: .monospaced)).foregroundColor(.gray)
-                    }
-                    
-                    Spacer()
-                    
-                    NavigationLink(destination: UserProfileView()) {
-                        HStack { Text("WHOAMI"); Image(systemName: "person.text.rectangle") }
-                            .font(.system(size: 14, weight: .bold, design: .monospaced)).foregroundColor(.green)
-                            .padding(8).background(Color.green.opacity(0.1)).cornerRadius(8)
-                    }
-                }
-                .padding(.top, 50).padding(.horizontal)
-                
+                identityRow
                 Spacer()
-                
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack(spacing: 0) {
-                        Text("root@ios:~$ ").font(.system(size: 16, weight: .bold, design: .monospaced)).foregroundColor(.green)
-                        Text("sudo sodoku").font(.system(size: 16, weight: .bold, design: .monospaced)).foregroundColor(.white)
-                    }
-                    .padding(.bottom, 20)
-                    
-                    Text("sudo sodoku")
-                        .font(.system(size: 54, weight: .heavy, design: .monospaced))
-                        .foregroundColor(.white)
-                        .shadow(color: .green.opacity(glowStrength), radius: 15)
-                        .shadow(color: .green.opacity(glowStrength * 0.6), radius: 40)
-                        .onAppear {
-                            withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
-                                glowStrength = 0.4
-                            }
-                        }
-                    
-                    Text("KERNEL_V\(AppConstants.marketingVersion)").font(.system(size: 14, design: .monospaced)).foregroundColor(.gray).padding(.top, 5)
-                    Text("// root access for logical purists")
-                        .font(.system(size: 12, design: .monospaced))
-                        .foregroundColor(.green.opacity(0.55))
-                        .padding(.top, 2)
-                }
-                Spacer()
-                
-                NavigationLink(destination: ModeSelectionView()) {
-                    HStack(spacing: 0) {
-                        Text("./execute").font(.system(size: 24, weight: .bold, design: .monospaced))
-                        Text("_").font(.system(size: 24, weight: .bold, design: .monospaced)).opacity(cursorOpacity)
-                            .onAppear { withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) { cursorOpacity = 0.0 } }
-                    }
-                    .foregroundColor(.green).padding(.horizontal, 40).padding(.vertical, 20)
-                    .background(Color.green.opacity(0.1)).cornerRadius(12)
-                    .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.green, lineWidth: 2))
-                }
-                
-                NavigationLink(destination: ArchiveView()) {
-                    HStack { Image(systemName: "archivebox"); Text("cd /archives") }
-                        .font(.system(size: 16, weight: .bold, design: .monospaced)).foregroundColor(.gray).padding()
-                }
-                NavigationLink(destination: StatsView()) {
-                    HStack { Image(systemName: "chart.bar.xaxis"); Text("cat /stats") }
-                        .font(.system(size: 16, weight: .bold, design: .monospaced)).foregroundColor(.gray).padding(.vertical, 4)
-                }
+
+                TerminalCommandComposer(
+                    awaitingComment: "# awaiting command",
+                    baseCommand: "sudo sodoku",
+                    completionComment: "# tab_completion:",
+                    options: [
+                        CommandOption(id: LandingTarget.breach.rawValue, label: "breach", detail: "// initiate new puzzle", color: .green),
+                        CommandOption(id: LandingTarget.archives.rawValue, label: "archives", detail: "// puzzle history & records", color: .gray),
+                        CommandOption(id: LandingTarget.stats.rawValue, label: "stats", detail: "// performance metrics", color: .gray),
+                        CommandOption(id: LandingTarget.whoami.rawValue, label: "whoami", detail: "// operator profile", color: .gray),
+                    ],
+                    hint: nil,
+                    onExecute: { option in
+                        launchTarget = LandingTarget(rawValue: option.id)
+                    },
+                    hero: { hero }
+                )
+                .id(composerKey)
+
                 Spacer()
             }
         }
+        .navigationDestination(item: $launchTarget) { target in
+            switch target {
+            case .breach:
+                ModeSelectionView(commandPrefix: "sudo sodoku")
+            case .archives:
+                ArchiveView(commandPrefix: "sudo sodoku archives")
+            case .stats:
+                StatsView(commandPrefix: "sudo sodoku stats")
+            case .whoami:
+                UserProfileView(commandPrefix: "sudo sodoku whoami")
+            }
+        }
+        .onAppear {
+            composerKey = UUID()
+        }
+    }
+
+    // MARK: - Sections
+
+    private var identityRow: some View {
+        HStack {
+            if gcManager.isAuthenticated {
+                if let photo = gcManager.playerPhoto {
+                    photo.resizable().scaledToFit().frame(width: 30, height: 30).clipShape(Circle()).overlay(Circle().stroke(Color.green, lineWidth: 1))
+                } else {
+                    Image(systemName: "person.circle.fill").font(.system(size: 30)).foregroundColor(.green)
+                }
+                Text("user: \(gcManager.playerName)").font(.system(size: 14, design: .monospaced)).foregroundColor(.green)
+            } else {
+                Image(systemName: "person.circle").font(.system(size: 30)).foregroundColor(.gray)
+                Text("user: guest").font(.system(size: 14, design: .monospaced)).foregroundColor(.gray)
+            }
+            Spacer()
+        }
+        .padding(.top, 50).padding(.horizontal)
+    }
+
+    private var hero: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("sudo sodoku")
+                .font(.system(size: 54, weight: .heavy, design: .monospaced))
+                .foregroundColor(.white)
+                .shadow(color: .green.opacity(glowStrength), radius: 15)
+                .shadow(color: .green.opacity(glowStrength * 0.6), radius: 40)
+                .onAppear {
+                    withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
+                        glowStrength = 0.4
+                    }
+                }
+
+            Text("KERNEL_V\(AppConstants.marketingVersion)").font(.system(size: 14, design: .monospaced)).foregroundColor(.gray).padding(.top, 5)
+            Text("// root access for logical purists")
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundColor(.green.opacity(0.55))
+                .padding(.top, 2)
+        }
+        .padding(.top, 20)
+        .padding(.bottom, 10)
     }
 }
-
-

--- a/SudoSodoku/Views/ModeSelectionView.swift
+++ b/SudoSodoku/Views/ModeSelectionView.swift
@@ -5,125 +5,44 @@ import SwiftUI
 /// the command, the command "executes", and the breach begins — flowing into
 /// the loading log, which opens with this very command.
 struct ModeSelectionView: View {
-    @State private var typedFlag = ""
-    @State private var pickedDifficulty: Difficulty?
-    @State private var isComposing = false
-    @State private var launchDifficulty: Difficulty?
-    @State private var cursorVisible = true
+    /// The shell session so far, e.g. "sudo sodoku" — echoed back before this
+    /// screen's own "breach" subcommand so the whole run reads as one line.
+    var commandPrefix: String = "sudo sodoku"
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var launchDifficulty: Difficulty?
+    @State private var composerKey = UUID()
 
     var body: some View {
         ZStack {
             TerminalBackground()
-            VStack(alignment: .leading, spacing: 34) {
-                commandLine
-                completionMenu
-                Spacer()
-                Text("# hint: higher difficulty_index -> higher elo yield")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundColor(.gray.opacity(0.6))
-                    .padding(.bottom, 12)
-            }
-            .padding(.horizontal)
+            TerminalCommandComposer(
+                awaitingComment: "# awaiting breach parameters",
+                baseCommand: "\(commandPrefix) breach",
+                completionComment: "# tab_completion:",
+                options: Difficulty.allCases.map { difficulty in
+                    CommandOption(
+                        id: difficulty.rawValue,
+                        label: difficulty.flag,
+                        detail: "DIFFICULTY_INDEX: \(difficulty.scoreRange.lowerBound)-\(difficulty.scoreRange.upperBound)",
+                        color: difficulty.color
+                    )
+                },
+                hint: "# hint: higher difficulty_index -> higher elo yield",
+                onExecute: { option in
+                    launchDifficulty = Difficulty(rawValue: option.id)
+                },
+                hero: { EmptyView() }
+            )
+            .id(composerKey)
         }
         .navigationBarTitleDisplayMode(.inline)
         .navigationDestination(item: $launchDifficulty) { difficulty in
             GameView(difficulty: difficulty)
         }
         .onAppear {
-            // Reset the composer when returning from a game.
-            typedFlag = ""
-            pickedDifficulty = nil
-            isComposing = false
-            withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
-                cursorVisible = false
-            }
-        }
-    }
-
-    // MARK: - Sections
-
-    private var commandLine: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("# awaiting breach parameters")
-                .font(.system(size: 12, design: .monospaced))
-                .foregroundColor(.gray)
-            HStack(spacing: 0) {
-                Text("root@ios:~$ ").foregroundColor(.green)
-                Text("sudo breach ").foregroundColor(.white)
-                Text(typedFlag).foregroundColor(pickedDifficulty?.color ?? .green)
-                Text("_")
-                    .foregroundColor(.green)
-                    .opacity(cursorVisible ? 1 : 0)
-            }
-            .font(.system(size: 17, weight: .bold, design: .monospaced))
-        }
-        .padding(.top, 24)
-    }
-
-    private var completionMenu: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("# tab_completion:")
-                .font(.system(size: 12, design: .monospaced))
-                .foregroundColor(.gray)
-            ForEach(Difficulty.allCases) { difficulty in
-                completionRow(difficulty)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func completionRow(_ difficulty: Difficulty) -> some View {
-        let isPicked = pickedDifficulty == difficulty
-        Button(action: { pick(difficulty) }) {
-            HStack {
-                VStack(alignment: .leading) {
-                    Text(difficulty.flag)
-                        .font(.system(size: 20, weight: .bold, design: .monospaced))
-                        .foregroundColor(difficulty.color)
-                    Text("DIFFICULTY_INDEX: \(difficulty.scoreRange.lowerBound)-\(difficulty.scoreRange.upperBound)")
-                        .font(.system(size: 12, design: .monospaced))
-                        .foregroundColor(.gray)
-                }
-                Spacer()
-                Image(systemName: "return")
-                    .foregroundColor(difficulty.color.opacity(isPicked ? 1 : 0.45))
-            }
-            .padding()
-            .background(isPicked ? difficulty.color.opacity(0.12) : Color.black.opacity(0.5))
-            .cornerRadius(12)
-            .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(difficulty.color.opacity(isPicked ? 1 : 0.5), lineWidth: 1)
-            )
-        }
-        .disabled(isComposing)
-    }
-
-    // MARK: - Composing
-
-    private func pick(_ difficulty: Difficulty) {
-        guard !isComposing else { return }
-        isComposing = true
-        pickedDifficulty = difficulty
-        HapticManager.shared.noteModeToggled()
-
-        let flag = difficulty.flag
-        Task {
-            if reduceMotion {
-                typedFlag = flag
-                try? await Task.sleep(for: .milliseconds(250))
-            } else {
-                for count in 1...flag.count {
-                    typedFlag = String(flag.prefix(count))
-                    HapticManager.shared.noteToggled()
-                    try? await Task.sleep(for: .milliseconds(45))
-                }
-                try? await Task.sleep(for: .milliseconds(280))
-            }
-            HapticManager.shared.digitPlaced() // return key
-            launchDifficulty = difficulty
+            // Fresh composer state each time this screen is entered, including
+            // when returning from a finished game.
+            composerKey = UUID()
         }
     }
 }

--- a/SudoSodoku/Views/StatsView.swift
+++ b/SudoSodoku/Views/StatsView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct StatsView: View {
+    var commandPrefix: String = "sudo sodoku stats"
+
     @ObservedObject private var stats = StatisticsManager.shared
 
     var body: some View {
@@ -8,6 +10,7 @@ struct StatsView: View {
             TerminalBackground()
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
+                    ExecutedCommandLine(command: commandPrefix)
                     sectionHeader("SYSTEM_OVERVIEW:")
                     LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
                         StatCard(title: "TOTAL_GAMES", value: "\(stats.overallStats.totalGames)", icon: "gamecontroller")

--- a/SudoSodoku/Views/UserProfileView.swift
+++ b/SudoSodoku/Views/UserProfileView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct UserProfileView: View {
+    var commandPrefix: String = "sudo sodoku whoami"
+
     @ObservedObject private var storage = StorageManager.shared
     @ObservedObject private var stats = StatisticsManager.shared
     @ObservedObject private var achievements = AchievementManager.shared
@@ -18,6 +20,9 @@ struct UserProfileView: View {
             TerminalBackground()
             ScrollView {
                 VStack(spacing: 30) {
+                    ExecutedCommandLine(command: commandPrefix)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, 20).padding(.horizontal)
                     VStack(spacing: 15) {
                         ZStack {
                             Circle().stroke(ratingInfo.color, lineWidth: 4).frame(width: 120, height: 120).shadow(color: ratingInfo.color.opacity(0.5), radius: 10)
@@ -31,7 +36,7 @@ struct UserProfileView: View {
                             Text(ratingInfo.title).font(.system(size: 24, weight: .heavy, design: .monospaced)).foregroundColor(ratingInfo.color)
                             Text("ELO RATING: \(storage.userRating)").font(.system(size: 16, design: .monospaced)).foregroundColor(.white)
                         }
-                    }.padding(.top, 40)
+                    }.padding(.top, 10)
 
                     LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 20) {
                         StatCard(title: "GAMES PLAYED", value: "\(stats.overallStats.totalGames)", icon: "gamecontroller")


### PR DESCRIPTION
## What

Follow-up to #49. The terminal-composer treatment from the difficulty
picker now covers the whole navigation flow instead of stopping at
one screen:

- Landing's actions (`breach`, `archives`, `stats`, `whoami`) are now
  typed tab-completion picks — same animated typing + haptics as the
  difficulty picker — instead of plain `NavigationLink` buttons.
- The composed command carries forward: picking `breach` lands on
  Mode Selection already showing `sudo sodoku breach `, and picking
  `archives`/`stats`/`whoami` opens that screen with the full command
  it was reached with echoed at the top (e.g. `sudo sodoku archives`).
  Navigation now reads as one continuous, accumulating shell session
  rather than disconnected screens.
- Extracted the shared typing/tab-completion behavior into
  `TerminalCommandComposer` (used by both Landing and Mode Selection)
  and a small `ExecutedCommandLine` readout for leaf screens.
- Mode Selection's tab-completion menu is pushed further down the
  screen instead of sitting directly under the prompt, using the
  empty space below.

Closes #47

## Test plan

- [x] Full suite: `xcodebuild test` — all 77 tests pass
- [x] Manual: screenshotted Landing, Mode Selection, Archives, Stats,
      and WhoAmI in the simulator to confirm layout and the
      accumulated command line render correctly on each

🤖 Generated with [Claude Code](https://claude.com/claude-code)