### PR TITLE
refactor: rename command-line branding to `sudo sudosodoku`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Every screen entered from the landing page now reads as one continuous, accumulating shell command instead of separate button taps: picking `breach`, `archives`, `stats`, or `whoami` types the subcommand into the prompt before navigating, and the destination screen echoes the full command (e.g. `sudo sodoku breach --easy`) it was reached with (#47)
+- Every screen entered from the landing page now reads as one continuous, accumulating shell command instead of separate button taps: picking `breach`, `archives`, `stats`, or `whoami` types the subcommand into the prompt before navigating, and the destination screen echoes the full command (e.g. `sudo sudosodoku breach --easy`) it was reached with (#47)
 - Mode selection's tab-completion menu is pushed further down the screen instead of sitting directly under the prompt (#47)
+- Command-line branding renamed from `sudo sodoku` to `sudo sudosodoku` everywhere the literal command appears: the landing hero title, the composer's base command, and every echoed command header (#51)
 
 ---
 

--- a/SudoSodoku/Views/ArchiveView.swift
+++ b/SudoSodoku/Views/ArchiveView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ArchiveView: View {
-    var commandPrefix: String = "sudo sodoku archives"
+    var commandPrefix: String = "sudo sudosodoku archives"
 
     @ObservedObject var storage = StorageManager.shared
     @State private var selectedRecordForAction: GameRecord?

--- a/SudoSodoku/Views/LandingView.swift
+++ b/SudoSodoku/Views/LandingView.swift
@@ -21,7 +21,7 @@ struct LandingView: View {
 
                 TerminalCommandComposer(
                     awaitingComment: "# awaiting command",
-                    baseCommand: "sudo sodoku",
+                    baseCommand: "sudo sudosodoku",
                     completionComment: "# tab_completion:",
                     options: [
                         CommandOption(id: LandingTarget.breach.rawValue, label: "breach", detail: "// initiate new puzzle", color: .green),
@@ -43,13 +43,13 @@ struct LandingView: View {
         .navigationDestination(item: $launchTarget) { target in
             switch target {
             case .breach:
-                ModeSelectionView(commandPrefix: "sudo sodoku")
+                ModeSelectionView(commandPrefix: "sudo sudosodoku")
             case .archives:
-                ArchiveView(commandPrefix: "sudo sodoku archives")
+                ArchiveView(commandPrefix: "sudo sudosodoku archives")
             case .stats:
-                StatsView(commandPrefix: "sudo sodoku stats")
+                StatsView(commandPrefix: "sudo sudosodoku stats")
             case .whoami:
-                UserProfileView(commandPrefix: "sudo sodoku whoami")
+                UserProfileView(commandPrefix: "sudo sudosodoku whoami")
             }
         }
         .onAppear {
@@ -79,7 +79,7 @@ struct LandingView: View {
 
     private var hero: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text("sudo sodoku")
+            Text("sudo sudosodoku")
                 .font(.system(size: 54, weight: .heavy, design: .monospaced))
                 .foregroundColor(.white)
                 .shadow(color: .green.opacity(glowStrength), radius: 15)

--- a/SudoSodoku/Views/ModeSelectionView.swift
+++ b/SudoSodoku/Views/ModeSelectionView.swift
@@ -5,9 +5,9 @@ import SwiftUI
 /// the command, the command "executes", and the breach begins — flowing into
 /// the loading log, which opens with this very command.
 struct ModeSelectionView: View {
-    /// The shell session so far, e.g. "sudo sodoku" — echoed back before this
+    /// The shell session so far, e.g. "sudo sudosodoku" — echoed back before this
     /// screen's own "breach" subcommand so the whole run reads as one line.
-    var commandPrefix: String = "sudo sodoku"
+    var commandPrefix: String = "sudo sudosodoku"
 
     @State private var launchDifficulty: Difficulty?
     @State private var composerKey = UUID()

--- a/SudoSodoku/Views/StatsView.swift
+++ b/SudoSodoku/Views/StatsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct StatsView: View {
-    var commandPrefix: String = "sudo sodoku stats"
+    var commandPrefix: String = "sudo sudosodoku stats"
 
     @ObservedObject private var stats = StatisticsManager.shared
     @ObservedObject private var storage = StorageManager.shared

--- a/SudoSodoku/Views/UserProfileView.swift
+++ b/SudoSodoku/Views/UserProfileView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct UserProfileView: View {
-    var commandPrefix: String = "sudo sodoku whoami"
+    var commandPrefix: String = "sudo sudosodoku whoami"
 
     @ObservedObject private var storage = StorageManager.shared
     @ObservedObject private var stats = StatisticsManager.shared


### PR DESCRIPTION
## Summary

Renames the literal command-line branding string `sudo sodoku` to `sudo sudosodoku` everywhere it appears as UI/terminal copy:

- Landing hero title (`LandingView`)
- The command composer's base command and the four navigation destinations (`LandingView`)
- Default `commandPrefix` on `ModeSelectionView`, `ArchiveView`, `StatsView`, `UserProfileView` (plus a doc comment)
- The stale example in the `CHANGELOG.md` `[Unreleased]` entry for #47

Out of scope by design: the app name/type `SudoSodoku`, the bundle id, and any other occurrence of `Sudoku`/`sodoku`. A repo-wide grep confirms no literal `sudo sodoku` remains.

Closes #51

## Verification

- Full test suite passes on iPhone 17 Pro simulator (`xcodebuild test`, ** TEST SUCCEEDED **)
- Visually verified in the simulator: the landing hero wraps cleanly to two lines at 54pt; the composed `root@ios:~$ sudo sudosodoku breach _` prompt and the echoed headers on the archives/stats/whoami screens all fit on one line with no clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)