### PR TITLE
fix: dark launch screen and deferred Game Center handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mode selection's tab-completion menu is pushed further down the screen instead of sitting directly under the prompt (#47)
 - Command-line branding renamed from `sudo sodoku` to `sudo sudosodoku` everywhere the literal command appears: the landing hero title, the composer's base command, and every echoed command header (#51)
 
+### Fixed
+
+- First launch after install stared at a pale white screen until the first frame arrived: the auto-generated launch screen uses `systemBackground` (white in light mode) while the app itself is always dark. The launch screen now boots in the terminal background color, so even the slow first launch (code-sign verification, cold caches — system costs the app can't remove) reads as the terminal warming up instead of a white hang. The Game Center handshake also waits a beat past the first frame so GameKit's first-run spin-up doesn't compete with the initial render
+
 ---
 
 ## [2.0.0] - 2026-07-08

--- a/Config/Info.plist
+++ b/Config/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Merged into the generated Info.plist via INFOPLIST_FILE. Lives
+	     outside SudoSodoku/ because the synchronized folder group would
+	     otherwise bundle it as a resource and collide with the processed
+	     Info.plist ("Multiple commands produce Info.plist").
+
+	     The launch screen must match TerminalBackground (0.05, 0.07, 0.10),
+	     not systemBackground: the app is always dark, and the default
+	     generated launch screen flashed white in light mode - a long white
+	     stare on slow first launches after install. -->
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIColorName</key>
+		<string>LaunchBackground</string>
+	</dict>
+</dict>
+</plist>

--- a/SudoSodoku.xcodeproj/project.pbxproj
+++ b/SudoSodoku.xcodeproj/project.pbxproj
@@ -330,11 +330,11 @@
 				DEVELOPMENT_TEAM = 4Q3P7THMVS;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Config/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = SudoSodoku;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.board-games";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -369,11 +369,11 @@
 				DEVELOPMENT_TEAM = 4Q3P7THMVS;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Config/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = SudoSodoku;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.board-games";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/SudoSodoku/Assets.xcassets/LaunchBackground.colorset/Contents.json
+++ b/SudoSodoku/Assets.xcassets/LaunchBackground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.100",
+          "green" : "0.070",
+          "red" : "0.050"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SudoSodoku/Views/ContentView.swift
+++ b/SudoSodoku/Views/ContentView.swift
@@ -11,7 +11,11 @@ struct ContentView: View {
             LandingView()
         }
         .preferredColorScheme(.dark)
-        .onAppear {
+        .task {
+            // Let the first frame land before GameKit's first-run spin-up
+            // (gamed XPC, signed-out probing) competes with it; signing in
+            // is optional and silent anyway (#21).
+            try? await Task.sleep(for: .seconds(1))
             GameCenterManager.shared.authenticateUser()
         }
     }


### PR DESCRIPTION
## Problem

First launch after install stared at a pale white screen for several seconds before the landing terminal appeared (reported by Kai with device screenshots; no tracked issue — issue creation was unavailable in this session).

## Diagnosis

The white screen is the auto-generated launch screen, not a hung view: `INFOPLIST_KEY_UILaunchScreen_Generation = YES` produces an empty launch screen backed by `systemBackground` — white in light mode — while the app always renders dark. First launch after install is when iOS pays one-time costs outside our code (code-signature verification, cold dyld caches, GameKit first spin-up), so the white screen lingers longest exactly then. A cold-install measurement on the simulator confirmed the app-side launch path is clean (storage load skips on fresh installs, the generator only runs on breach, auth is async).

## Fix

- New `LaunchBackground` asset color matching `TerminalBackground` (0.05, 0.07, 0.10); the launch screen now boots dark, so even a slow first launch reads as the terminal warming up.
- Provided via a minimal `Config/Info.plist` merged through `INFOPLIST_FILE`. It lives outside `SudoSodoku/` because the synchronized folder group would otherwise bundle it as a resource and fail the build with "Multiple commands produce Info.plist" (verified both ways).
- The Game Center handshake now starts one second after the first frame instead of during it, keeping GameKit's first-run XPC out of the initial render.

## Verification

- Fresh-install launch on an erased iPhone 17 Pro simulator, screenshot-sampled: launch screen renders dark (status bar auto-flips to light content), then flows into the landing terminal — no white frame captured. Pre-fix, the same measurement showed a pure-white launch screen for ~1–1.5s.
- Merged Info.plist inspected: `UILaunchScreen → UIColorName = LaunchBackground`.
- `xcodebuild test` on iPhone 17 Pro simulator: **81/81 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)