### PR TITLE
feat: landing terminal boots in on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The landing terminal boots in on launch: `sudo sudosodoku` types itself into the prompt and the tab-completion menu materializes once the command lands — once per process, so back-navigations get the materialized prompt; silent (no keystroke haptics) and instant under Reduce Motion (#54)
+
 ### Changed
 
 - Every screen entered from the landing page now reads as one continuous, accumulating shell command instead of separate button taps: picking `breach`, `archives`, `stats`, or `whoami` types the subcommand into the prompt before navigating, and the destination screen echoes the full command (e.g. `sudo sudosodoku breach --easy`) it was reached with (#47)

--- a/SudoSodoku/Views/Components/TerminalCommandComposer.swift
+++ b/SudoSodoku/Views/Components/TerminalCommandComposer.swift
@@ -21,6 +21,11 @@ struct TerminalCommandComposer<Hero: View>: View {
     let completionComment: String
     let options: [CommandOption]
     let hint: String?
+    /// When true, the terminal "boots in" on appear: the base command types
+    /// itself into the prompt and the completion menu materializes once it
+    /// lands. The landing screen passes this on the first appearance after
+    /// process launch, so the launch screen flows into a booting terminal.
+    var bootsIn: Bool = false
     let onExecute: (CommandOption) -> Void
     @ViewBuilder var hero: () -> Hero
 
@@ -28,6 +33,10 @@ struct TerminalCommandComposer<Hero: View>: View {
     @State private var pickedOption: CommandOption?
     @State private var isComposing = false
     @State private var cursorVisible = true
+    @State private var typedBase = ""
+    @State private var bootComplete = false
+
+    private var isBooting: Bool { bootsIn && !bootComplete }
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -50,6 +59,7 @@ struct TerminalCommandComposer<Hero: View>: View {
             withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
                 cursorVisible = false
             }
+            if isBooting { bootIn() }
         }
     }
 
@@ -62,7 +72,7 @@ struct TerminalCommandComposer<Hero: View>: View {
                 .foregroundColor(.gray)
             HStack(spacing: 0) {
                 Text("root@ios:~$ ").foregroundColor(.green)
-                Text(baseCommand + " ").foregroundColor(.white)
+                Text(isBooting ? typedBase : baseCommand + " ").foregroundColor(.white)
                 Text(typedSuffix).foregroundColor(pickedOption?.color ?? .green)
                 Text("_")
                     .foregroundColor(.green)
@@ -82,6 +92,9 @@ struct TerminalCommandComposer<Hero: View>: View {
                 completionRow(option)
             }
         }
+        // Opacity, not `if`: the menu holds its slot between the Spacers
+        // while booting, so nothing shifts when it materializes.
+        .opacity(isBooting ? 0 : 1)
     }
 
     @ViewBuilder
@@ -109,7 +122,28 @@ struct TerminalCommandComposer<Hero: View>: View {
                     .stroke(option.color.opacity(isPicked ? 1 : 0.5), lineWidth: 1)
             )
         }
-        .disabled(isComposing)
+        .disabled(isComposing || isBooting)
+    }
+
+    // MARK: - Booting
+
+    /// Types the base command into the prompt, then reveals the completion
+    /// menu. Silent (no per-keystroke haptics — nobody is typing) and
+    /// instant under Reduce Motion.
+    private func bootIn() {
+        Task {
+            if !reduceMotion {
+                try? await Task.sleep(for: .milliseconds(200))
+                for count in 1...baseCommand.count {
+                    typedBase = String(baseCommand.prefix(count))
+                    try? await Task.sleep(for: .milliseconds(40))
+                }
+                try? await Task.sleep(for: .milliseconds(120))
+            }
+            withAnimation(reduceMotion ? nil : .easeOut(duration: 0.25)) {
+                bootComplete = true
+            }
+        }
     }
 
     // MARK: - Composing

--- a/SudoSodoku/Views/LandingView.swift
+++ b/SudoSodoku/Views/LandingView.swift
@@ -9,6 +9,10 @@ struct LandingView: View {
     @State private var glowStrength = 1.0
     @State private var launchTarget: LandingTarget?
     @State private var composerKey = UUID()
+    // The terminal boots in (base command types itself) only on the first
+    // appearance after launch; back-navigations get the materialized prompt.
+    @State private var bootsIn = true
+    @State private var hasAppearedBefore = false
     @ObservedObject var gcManager = GameCenterManager.shared
 
     var body: some View {
@@ -30,6 +34,7 @@ struct LandingView: View {
                         CommandOption(id: LandingTarget.whoami.rawValue, label: "whoami", detail: "// operator profile", color: .gray),
                     ],
                     hint: nil,
+                    bootsIn: bootsIn,
                     onExecute: { option in
                         launchTarget = LandingTarget(rawValue: option.id)
                     },
@@ -53,6 +58,8 @@ struct LandingView: View {
             }
         }
         .onAppear {
+            if hasAppearedBefore { bootsIn = false }
+            hasAppearedBefore = true
             composerKey = UUID()
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #53 (dark launch screen): the launch screen now flows into a *booting* terminal instead of cutting to a fully materialized one. On the first appearance after process launch, the landing prompt types its base command in (`root@ios:~$ ` types `sudo sudosodoku` at 40ms/char after a 200ms beat) and the tab-completion menu materializes once the command lands.

- The menu holds its layout slot while hidden (opacity, not removal), so nothing shifts when it appears; its buttons are disabled until the boot completes.
- Plays once per process — back-navigations to the landing screen get the materialized prompt.
- Silent: no per-keystroke haptics (nobody is typing).
- Instant under Reduce Motion.
- `bootsIn` defaults to false, so the mode-selection screen's composer is unaffected.

Closes #54

## Verification

- Screenshot-sampled a cold launch on the iPhone 17 Pro simulator (Release): mid-boot frame shows the bare `root@ios:~$ _` prompt with the menu slot empty; final frame shows the typed command and materialized menu.
- `xcodebuild test` on iPhone 17 Pro simulator: **81/81 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)