### PR TITLE
fix: solved records are immutable history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Solved records are now immutable history: restarting a solved puzzle from the archive (`sudo reboot`) or the in-game RETRY forked in place under the same record id, so the first autosave overwrote the completed run — the solve silently vanished from SOLVED counts, personal bests, and recent completions while the ELO it granted remained. Both paths now fork a fresh record; the original solve stays
+- Viewing a solved record (`cat solution`) re-saved it with a fresh `lastPlayedTime`, so merely looking at an old solve bumped it to today and reshuffled the archive order. Viewing is read-only now
 - First launch after install stared at a pale white screen until the first frame arrived: the auto-generated launch screen uses `systemBackground` (white in light mode) while the app itself is always dark. The launch screen now boots in the terminal background color, so even the slow first launch (code-sign verification, cold caches — system costs the app can't remove) reads as the terminal warming up instead of a white hang. The Game Center handshake also waits a beat past the first frame so GameKit's first-run spin-up doesn't compete with the initial render
 
 ---

--- a/SudoSodoku/Models/GameRecord.swift
+++ b/SudoSodoku/Models/GameRecord.swift
@@ -60,16 +60,28 @@ struct GameRecord: Codable, Identifiable, Hashable {
         }
     }
 
+    /// A fresh attempt at the same puzzle, under a new identity. The new id
+    /// is the point: a solved record is immutable history (SOLVED counts,
+    /// personal bests, recent completions all derive from it), so a restart
+    /// must never let its autosaves overwrite the original in storage.
     func restartedCopy() -> GameRecord {
-        var restarted = self
-        restarted.lastPlayedTime = Date()
-        restarted.playerBoard = Array(repeating: 0, count: 81)
-        restarted.playerNotes = Array(repeating: [], count: 81)
-        restarted.isSolved = false
-        restarted.ratingChange = nil
-        restarted.undoCount = 0
-        restarted.playDuration = 0
-        return restarted
+        GameRecord(
+            id: UUID(),
+            startTime: Date(),
+            lastPlayedTime: Date(),
+            difficulty: difficulty,
+            difficultyIndex: difficultyIndex,
+            initialBoard: initialBoard,
+            solution: solution,
+            playerBoard: Array(repeating: 0, count: 81),
+            playerNotes: Array(repeating: [], count: 81),
+            isSolved: false,
+            ratingChange: nil,
+            isArchived: isArchived,
+            isFavorite: isFavorite,
+            undoCount: 0,
+            playDuration: 0
+        )
     }
 }
 

--- a/SudoSodoku/ViewModels/SudokuGame.swift
+++ b/SudoSodoku/ViewModels/SudokuGame.swift
@@ -371,6 +371,14 @@ class SudokuGame: ObservableObject {
     func replayCurrentGame() {
         guard currentRecordID != nil else { return }
 
+        // A solved run is immutable history: replaying it forks a fresh
+        // record instead of resetting the completed one in place (which
+        // silently dropped the solve from stats and personal bests while
+        // the ELO it granted remained).
+        if isSolved {
+            currentRecordID = UUID()
+        }
+
         for index in board.indices where !board[index].isGiven {
             board[index].value = nil
             board[index].notes = []
@@ -387,17 +395,6 @@ class SudokuGame: ObservableObject {
         streak = 0
         victoryUnlocks = []
         resetClock(to: 0, running: true)
-        saveCurrentState()
-    }
-
-    func showSolution() {
-        for index in board.indices {
-            board[index].value = board[index].solutionValue
-            board[index].notes = []
-            board[index].isError = false
-        }
-        isSolved = true
-        pauseClock()
         saveCurrentState()
     }
 

--- a/SudoSodoku/Views/GameView.swift
+++ b/SudoSodoku/Views/GameView.swift
@@ -196,8 +196,11 @@ struct GameView: View {
             }
 
             if let record {
+                // Viewing is read-only: loadFromRecord already renders a
+                // solved record's full board. The old showSolution() call
+                // here re-saved the record, bumping lastPlayedTime on every
+                // visit - "cat solution" made an old solve claim today's date.
                 game.loadFromRecord(record)
-                if record.isSolved { game.showSolution() }
             } else if let difficulty {
                 if SudoersJoke.shouldShow(for: difficulty) {
                     showSudoersJoke = true

--- a/SudoSodokuTests/SolvedRecordImmutabilityTests.swift
+++ b/SudoSodokuTests/SolvedRecordImmutabilityTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import SudoSodoku
+
+/// A solved record is immutable history: stats, personal bests, and recent
+/// completions all derive from it. Restarting or replaying a solved puzzle
+/// must fork a fresh record, never overwrite the original in storage.
+final class SolvedRecordImmutabilityTests: XCTestCase {
+
+    private var fixtureIDs: [UUID] = []
+
+    override func tearDown() {
+        for id in fixtureIDs {
+            StorageManager.shared.deleteRecord(id: id)
+        }
+        fixtureIDs = []
+        super.tearDown()
+    }
+
+    func testRestartedCopyMintsNewIdentity() {
+        let original = makeRecord(emptyIndices: [0], solved: true, playDuration: 120)
+        let restarted = original.restartedCopy()
+
+        XCTAssertNotEqual(restarted.id, original.id,
+                          "A restart must fork: the same id would make autosaves overwrite the solved original")
+        XCTAssertFalse(restarted.isSolved)
+        XCTAssertNil(restarted.ratingChange)
+        XCTAssertEqual(restarted.playDuration, 0)
+        XCTAssertEqual(restarted.undoCount, 0)
+        XCTAssertEqual(restarted.playerBoard, Array(repeating: 0, count: 81))
+        XCTAssertEqual(restarted.initialBoard, original.initialBoard, "Same puzzle")
+        XCTAssertEqual(restarted.solution, original.solution)
+    }
+
+    func testReplayOfSolvedGameForksAndPreservesTheSolve() {
+        let solved = makeRecord(emptyIndices: [0], solved: true, playDuration: 300)
+        fixtureIDs.append(solved.id)
+        StorageManager.shared.saveGame(solved)
+
+        let game = SudokuGame()
+        game.loadFromRecord(solved)
+        game.replayCurrentGame()
+        if let forkedID = game.currentRecordID { fixtureIDs.append(forkedID) }
+
+        XCTAssertNotEqual(game.currentRecordID, solved.id,
+                          "Replaying a solved game must fork a new record")
+
+        let storedOriginal = StorageManager.shared.records.first { $0.id == solved.id }
+        XCTAssertEqual(storedOriginal?.isSolved, true,
+                       "The historical solve must survive the replay")
+        XCTAssertEqual(storedOriginal?.playDuration ?? -1, 300, accuracy: 1.0)
+
+        let fork = StorageManager.shared.records.first { $0.id == game.currentRecordID }
+        XCTAssertEqual(fork?.isSolved, false, "The fork starts as a fresh attempt")
+    }
+
+    func testReplayOfUnsolvedGameStaysInPlace() {
+        let inProgress = makeRecord(emptyIndices: [0, 1], solved: false)
+        fixtureIDs.append(inProgress.id)
+        StorageManager.shared.saveGame(inProgress)
+
+        let game = SudokuGame()
+        game.loadFromRecord(inProgress)
+        game.replayCurrentGame()
+
+        XCTAssertEqual(game.currentRecordID, inProgress.id,
+                       "Retrying an unsolved game is an in-place reset, not a fork")
+    }
+
+    // MARK: - Fixtures
+
+    /// A valid completed sudoku via the row-shift pattern.
+    private func solutionValue(at index: Int) -> Int {
+        let row = index / 9
+        let col = index % 9
+        return (row * 3 + row / 3 + col) % 9 + 1
+    }
+
+    private func makeRecord(emptyIndices: [Int], solved: Bool, playDuration: TimeInterval = 0) -> GameRecord {
+        let solution = (0..<81).map { solutionValue(at: $0) }
+        var initial = solution
+        for index in emptyIndices { initial[index] = 0 }
+        var player = Array(repeating: 0, count: 81)
+        if solved {
+            for index in emptyIndices { player[index] = solution[index] }
+        }
+
+        return GameRecord(
+            id: UUID(),
+            startTime: Date(),
+            lastPlayedTime: Date(),
+            difficulty: "EASY",
+            difficultyIndex: 10,
+            initialBoard: initial,
+            solution: solution,
+            playerBoard: player,
+            playerNotes: Array(repeating: [], count: 81),
+            isSolved: solved,
+            ratingChange: solved ? 10 : nil,
+            playDuration: playDuration
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Found in the pre-submission consistency audit: three flows mutated solved records, so derived surfaces (stats, personal bests, archive order) disagreed with the rating and achievements — the same family as the wipe/stats desync (#41).

1. **Archive → RESTART (`sudo reboot`)**: `restartedCopy()` kept the same record id; the restarted session's first autosave overwrote the solved original. The solve silently vanished from SOLVED counts, personal bests, recent completions, and the difficulty distribution, while the ELO it granted and unlocked achievements remained.
2. **In-game RETRY (Clear) on a solved game**: `replayCurrentGame()` reset the completed record in place — same erasure.
3. **Archive → SHOW ANSWER (`cat solution`)**: viewing a solved record re-saved it with `lastPlayedTime = now`, bumping an old solve to today's date and reshuffling `USER_LOGS` on every visit.

## Fix

One invariant: **a solved record is immutable history.**

- `restartedCopy()` mints a new `id` and `startTime` — a restart is a fork, never an overwrite
- `replayCurrentGame()` forks a fresh record id when the run is solved; retrying an *unsolved* game remains an in-place reset
- Viewing is read-only: the persisting `showSolution()` is deleted (its only caller was the viewing path, and `loadFromRecord` already renders a solved record's full board)

## Verification

- New `SolvedRecordImmutabilityTests`: restart mints a new identity; replaying a solved game forks and the original solve survives in storage; replaying an unsolved game stays in place
- `xcodebuild test` on iPhone 17 Pro simulator: **84/84 passed**

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)