### PR TITLE
docs: release prep for the v2.0.0 App Store submission

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,8 +6,8 @@ We actively support security updates for the following versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.0.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| 2.0.x   | :white_check_mark: |
+| < 2.0   | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -68,15 +68,15 @@ If you're contributing code:
 
 #### Data Privacy
 
-* **Local Storage**: Game data is stored locally on device
-* **No Data Collection**: We don't collect user data
-* **Game Center**: Uses Apple's Game Center (subject to Apple's privacy policy)
+* **Local Storage**: All game data — history, rating, achievements — lives in a single local JSON file on device (`StorageManager`, atomic writes). Nothing is uploaded by the app itself
+* **No Data Collection**: No analytics, no tracking, no accounts, no third-party SDKs
+* **Game Center (optional)**: Signing in submits leaderboard scores (solve times, ELO) and achievement unlocks through Apple's Game Center, subject to Apple's privacy policy. The app is fully playable as a guest without it
 
 #### Permissions
 
 SudoSodoku requests minimal permissions:
 
-* **Game Center**: For user authentication and leaderboards (optional)
+* **Game Center**: For user authentication, leaderboards, and achievements (optional — never presented at launch)
 
 #### Third-Party Dependencies
 
@@ -97,7 +97,7 @@ None at this time. All known security issues will be listed here once resolved.
 Security updates will be:
 
 * Documented in CHANGELOG.md
-* Released as patch versions (e.g., 1.0.1, 1.0.2)
+* Released as patch versions (e.g., 2.0.1, 2.0.2)
 * Communicated through GitHub releases
 * Prioritized over feature development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- The landing terminal boots in on launch: `sudo sudosodoku` types itself into the prompt and the tab-completion menu materializes once the command lands — once per process, so back-navigations get the materialized prompt; silent (no keystroke haptics) and instant under Reduce Motion (#54)
-
-### Changed
-
-- Every screen entered from the landing page now reads as one continuous, accumulating shell command instead of separate button taps: picking `breach`, `archives`, `stats`, or `whoami` types the subcommand into the prompt before navigating, and the destination screen echoes the full command (e.g. `sudo sudosodoku breach --easy`) it was reached with (#47)
-- Mode selection's tab-completion menu is pushed further down the screen instead of sitting directly under the prompt (#47)
-- Command-line branding renamed from `sudo sodoku` to `sudo sudosodoku` everywhere the literal command appears: the landing hero title, the composer's base command, and every echoed command header (#51)
-
-### Fixed
-
-- Solved records are now immutable history: restarting a solved puzzle from the archive (`sudo reboot`) or the in-game RETRY forked in place under the same record id, so the first autosave overwrote the completed run — the solve silently vanished from SOLVED counts, personal bests, and recent completions while the ELO it granted remained. Both paths now fork a fresh record; the original solve stays
-- Viewing a solved record (`cat solution`) re-saved it with a fresh `lastPlayedTime`, so merely looking at an old solve bumped it to today and reshuffled the archive order. Viewing is read-only now
-- First launch after install stared at a pale white screen until the first frame arrived: the auto-generated launch screen uses `systemBackground` (white in light mode) while the app itself is always dark. The launch screen now boots in the terminal background color, so even the slow first launch (code-sign verification, cold caches — system costs the app can't remove) reads as the terminal warming up instead of a white hang. The Game Center handshake also waits a beat past the first frame so GameKit's first-run spin-up doesn't compete with the initial render
-
 ---
 
 ## [2.0.0] - 2026-07-08
@@ -37,6 +21,7 @@ v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a fu
 
 ### Added
 
+- The landing terminal boots in on launch: `sudo sudosodoku` types itself into the prompt and the tab-completion menu materializes once the command lands — once per process, so back-navigations get the materialized prompt; silent (no keystroke haptics) and instant under Reduce Motion (#54)
 - Completion time tracking: play clock accumulates active time per game, pauses in the background and freezes on victory; terminal-style `T+MM:SS` timer in the game header (toggleable via the game menu), duration shown on victory, in archive rows, and in personal bests (#4)
 - Auto-clear pencil notes: placing a number removes that digit from notes in the same row, column, and box; undo/redo treats the placement and cleared notes as one compound move (#5)
 - Numpad digit keys dim and strike through once all nine instances of a digit are placed; undo/clear revives them (#6)
@@ -59,6 +44,9 @@ v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a fu
 
 ### Changed
 
+- Every screen entered from the landing page now reads as one continuous, accumulating shell command instead of separate button taps: picking `breach`, `archives`, `stats`, or `whoami` types the subcommand into the prompt before navigating, and the destination screen echoes the full command (e.g. `sudo sudosodoku breach --easy`) it was reached with (#47)
+- Mode selection's tab-completion menu is pushed further down the screen instead of sitting directly under the prompt (#47)
+- Command-line branding renamed from `sudo sodoku` to `sudo sudosodoku` everywhere the literal command appears: the landing hero title, the composer's base command, and every echoed command header (#51)
 - Statistics tell the truth for a no-fail game: WIN_RATE is gone (boards are only finished or unfinished — abandoning isn't losing), BEST_EFF is demoted from the headline (it contradicted the fearless-undo philosophy); SYSTEM_OVERVIEW now shows SOLVED / ELO / FASTEST / HARDEST, and a personal best is the fastest solve (efficiency stays as per-record detail) (#46)
 - Puzzles now read as hand-crafted: each board picks an aesthetic clue-pattern style at random (180° rotational, horizontal/vertical mirror, diagonal, anti-diagonal, or deliberately free — hand-made collections vary, symmetry is common but not universal), and every difficulty has a technique identity enforced at generation — EASY solves with singles and always offers parallel moves, MEDIUM never demands more than locked candidates / naked pairs, HARD is designed around a required intermediate "aha" (and never needs more — no guessing), MASTER resists intermediate techniques entirely (#39)
 - Leaderboard submissions previously sent the puzzle difficulty index (0-100), which ranked players by generation luck; scores are now actual performance — solve time per difficulty, ELO on the global board (#11)
@@ -78,6 +66,9 @@ v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a fu
 
 ### Fixed
 
+- Solved records are now immutable history: restarting a solved puzzle from the archive (`sudo reboot`) or the in-game RETRY forked in place under the same record id, so the first autosave overwrote the completed run — the solve silently vanished from SOLVED counts, personal bests, and recent completions while the ELO it granted remained. Both paths now fork a fresh record; the original solve stays (#56)
+- Viewing a solved record (`cat solution`) re-saved it with a fresh `lastPlayedTime`, so merely looking at an old solve bumped it to today and reshuffled the archive order. Viewing is read-only now (#56)
+- First launch after install stared at a pale white screen until the first frame arrived: the auto-generated launch screen uses `systemBackground` (white in light mode) while the app itself is always dark. The launch screen now boots in the terminal background color, and the Game Center handshake waits a beat past the first frame so GameKit's first-run spin-up doesn't compete with the initial render
 - The secret INCIDENT_REPORTED achievement wasn't actually secret: the profile wall listed its title with only the description masked. Hidden achievements are now entirely absent from the wall until earned, matching Game Center's Hidden semantics
 - Profile (WHOAMI) statistics desynced from storage: `@Published` emits on willSet, and the stats refresh read the records back through the singleton — always one mutation behind. Zeros stuck on a fresh launch, numbers survived the debug wipe, and only playing a move "fixed" them. Stats now derive from the emitted value (#41)
 - Achievement unlocks had no visible feedback: the toast raced the victory overlay and could expire unseen behind the matrix rain. Unlocks now render inside the victory sequence itself (`>> UNLOCKED: ...` under the ELO ticker), and the sudoers interstitial types out its own secret-achievement line — the separate toast and its cross-view choreography are gone

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,319 +1,136 @@
 # Contributing to SudoSodoku
 
-Thank you for your interest in contributing to SudoSodoku! This document provides guidelines and instructions for contributing to the project.
+Thank you for your interest in contributing! This document describes how this repository actually works — read it before opening a PR.
 
-## 🎯 How to Contribute
+## 🎯 What We Welcome
 
-We welcome contributions of all kinds:
+* 🐛 **Bug reports** — especially consistency bugs (stats, archives, achievements disagreeing with each other)
+* 💡 **Feature requests** — measured against the four-pillar philosophy in the [README](README.md)
+* 📝 **Documentation** improvements
+* ⚡ **Performance** work (the generator's dig loop is the hot path)
+* 🧪 **Tests** — generator, rating, and storage logic must stay covered
 
-* 🐛 **Bug Reports**: Help us identify and fix issues
-* 💡 **Feature Requests**: Suggest new features or improvements
-* 📝 **Documentation**: Improve documentation and code comments
-* 🎨 **UI/UX Improvements**: Enhance the user interface
-* ⚡ **Performance**: Optimize code and algorithms
-* 🧪 **Testing**: Add tests or improve test coverage
-* 🌍 **Localization**: Translate the app to other languages
+### 🚫 What we will decline
+
+* Ads, paywalls, lives, guilt mechanics, or anything that violates "pure logic, zero noise"
+* iPad or macOS support (deferred indefinitely — iPhone only, `TARGETED_DEVICE_FAMILY = 1`)
+* Animations that ignore Reduce Motion, or sounds that force themselves on
+* Telemetry, analytics, or anything that moves user data off the device
+* Closed-source dependencies
 
 ## 🚀 Getting Started
 
 ### Prerequisites
 
-* macOS 13.0+ (for iOS development)
-* Xcode 15.0+ with Command Line Tools
-* iOS 17.0+ deployment target
-* Git
+* macOS 13.0+, Xcode 15.0+ with Command Line Tools, Git
 
-### Setting Up the Development Environment
+### Setup
 
-1. **Fork the repository**
+1. **Fork and clone**
 
    ```bash
-   # Fork on GitHub, then clone your fork
    git clone https://github.com/YOUR_USERNAME/SudoSodoku.git
    cd SudoSodoku
    ```
 
-2. **Open in Xcode**
+2. **Open `SudoSodoku.xcodeproj`**, set your own Team under Signing & Capabilities.
+
+3. **Build and run**: `Cmd + R` in Xcode, or `./build.sh` / `./play.sh` from the terminal.
+
+## ⚠️ Project-Specific Rules (the ones that bite)
+
+These are the non-obvious constraints; violating them breaks CI or the App Store build:
+
+1. **Never commit directly to `main`.** Every change — including docs-only — goes through a feature branch and a pull request.
+
+2. **`IPHONEOS_DEPLOYMENT_TARGET` must stay the literal `17.0`** in `project.pbxproj`. Do **not** accept Xcode's "Update to recommended settings" suggestion that rewrites it to `$(RECOMMENDED_IPHONEOS_DEPLOYMENT_TARGET)` — Xcode Cloud resolves that macro to nothing and the build fails with iOS 16/17 availability errors.
+
+3. **Don't hand-register files in `project.pbxproj`.** The project uses Xcode's synchronized folder groups: new files under `SudoSodoku/` or `SudoSodokuTests/` are picked up automatically. (Corollary: files that must *not* be bundled as resources — like the merged `Info.plist` — live outside those folders, e.g. `Config/`.)
+
+4. **Update `CHANGELOG.md` (`[Unreleased]` section) in the same PR** as the change it describes.
+
+5. **Run the full test suite before every PR**:
 
    ```bash
-   open SudoSodoku.xcodeproj
+   xcodebuild test -project SudoSodoku.xcodeproj -scheme SudoSodoku \
+     -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
    ```
 
-3. **Configure Signing**
-   * Select the SudoSodoku target
-   * Go to Signing & Capabilities
-   * Set your development team
+   New generator, rating, or storage logic needs matching unit tests in `SudoSodokuTests/`.
 
-4. **Build and Run**
+## 📋 Workflow
 
-   ```bash
-   # Using build script
-   ./build.sh
-   
-   # Or in Xcode: Cmd+B to build, Cmd+R to run
-   ```
-
-## 📋 Development Workflow
-
-### 1. Create a Branch
+### 1. Branch
 
 ```bash
-git checkout -b feature/your-feature-name
-# or
-git checkout -b fix/your-bug-fix
+git checkout -b feature/your-feature-name   # or fix/, docs/, refactor/, test/
 ```
 
-**Branch Naming Convention:**
-
-* `feature/` - New features
-* `fix/` - Bug fixes
-* `docs/` - Documentation updates
-* `refactor/` - Code refactoring
-* `test/` - Test additions/updates
-
-### 2. Make Your Changes
-
-* Follow the existing code style
-* Write clear, self-documenting code
-* Add comments for complex logic (in English)
-* Follow the MVVM architecture pattern
-* Keep functions focused and small
-
-### 3. Test Your Changes
-
-* Test on iOS Simulator
-* Test on physical device if possible
-* Ensure no regressions
-* Test edge cases
-
-### 4. Commit Your Changes
-
-```bash
-git add .
-git commit -m "feat: Add detailed statistics feature"
-```
-
-**Commit Message Format:**
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
+### 2. Commit — Conventional Commits
 
 ```
-<type>(<scope>): <subject>
-
-<body>
-
-<footer>
+<type>: <subject>
 ```
 
-**Types:**
-
-* `feat`: New feature
-* `fix`: Bug fix
-* `docs`: Documentation
-* `style`: Code style (formatting, etc.)
-* `refactor`: Code refactoring
-* `test`: Adding tests
-* `chore`: Maintenance tasks
-
-**Examples:**
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`. Examples from this repo's history:
 
 ```
-feat(Statistics): Add completion time tracking
-fix(GameView): Resolve cell selection animation issue
-docs(README): Update build instructions
+feat: landing terminal boots in on launch
+fix: solved records are immutable history
+refactor: rename command-line branding to `sudo sudosodoku`
 ```
 
-### 5. Push and Create Pull Request
+### 3. Pull Request
 
-```bash
-git push origin feature/your-feature-name
-```
+* Clear title and description; reference related issues (`Closes #N`)
+* Screenshots or screen recordings for UI changes
+* State how you tested (suite results, device/simulator)
 
-Then create a Pull Request on GitHub with:
+## 🎨 Code & Design Style
 
-* Clear title and description
-* Reference related issues
-* Screenshots/GIFs for UI changes
-* Testing notes
+### Swift
 
-## 🎨 Code Style Guidelines
+* Follow the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/)
+* MVVM: views render, `SudokuGame` owns game logic, managers own their domain (storage, rating, haptics, Game Center)
+* All code comments and documentation in **English**; explain *why*, not *what*
+* Prefer `let`, `guard` for early returns, small focused functions
 
-### Swift Style
+### The Terminal Aesthetic (UI copy)
 
-* Follow [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/)
-* Use meaningful variable and function names
-* Keep functions under 50 lines when possible
-* Use `guard` statements for early returns
-* Prefer `let` over `var` when possible
+* Monospaced everywhere, `UPPER_SNAKE` labels (`SYSTEM_OVERVIEW:`, `NO_RECORDS_FOUND`)
+* Shell-flavored strings (`cat /leaderboard`, `$ rm -rf /user_data`, `# awaiting command`)
+* The navigation fiction is one accumulating command line (`root@ios:~$ sudo sudosodoku …`) — new screens should extend it, not break it
 
-### Architecture
+### Accessibility & Feel (non-negotiable)
 
-* **MVVM Pattern**: Maintain separation of Models, Views, and ViewModels
-* **Single Responsibility**: Each class/struct should have one clear purpose
-* **Dependency Injection**: Use shared instances (like `StorageManager.shared`) appropriately
-* **ObservableObject**: Use `@Published` properties for reactive updates
+* **Every animation must respect Reduce Motion** — provide an instant path
+* Sounds are never forced on
+* Haptics go through `HapticManager`'s semantic vocabulary — views express intent, never raw generators
 
-### File Organization
+### Data Integrity Invariants
 
-```
-SudoSodoku/
-├── Models/          # Data models
-├── ViewModels/      # Business logic
-├── Managers/        # System managers
-├── Views/           # UI components
-│   ├── Components/  # Reusable components
-│   └── Styles/      # Custom styles
-└── Algorithms/      # Core algorithms
-```
-
-### Comments
-
-* All comments must be in **English**
-* Use `// MARK:` comments to organize code sections
-* Document complex algorithms
-* Explain "why" not just "what"
-
-### Example
-
-```swift
-// MARK: - Game Generation
-
-/// Generates a new Sudoku puzzle for the specified difficulty level.
-/// - Parameter difficulty: The target difficulty (Easy, Medium, Hard, Master)
-/// - Returns: A tuple containing (puzzle, solution, difficultyScore)
-func generateGame(for difficulty: Difficulty) {
-    // Implementation
-}
-```
+* **A solved record is immutable history**: restarts/replays fork a new record; viewing never writes
+* Persistence goes through `StorageManager` (single JSON file, atomic writes); new fields need decode defaults so old saves keep loading (see `GameRecord.init(from:)`)
+* Statistics derive from emitted values, not singleton read-backs (`@Published` emits on *willSet*)
 
 ## 🐛 Reporting Bugs
 
-### Before Submitting
-
-1. Check if the bug has already been reported
-2. Test on the latest version
-3. Try to reproduce the issue
-
-### Bug Report Template
-
-When creating an issue, include:
-
-* **Description**: Clear description of the bug
-* **Steps to Reproduce**: Detailed steps to reproduce
-* **Expected Behavior**: What should happen
-* **Actual Behavior**: What actually happens
-* **Screenshots**: If applicable
-* **Environment**:
-  * iOS version
-  * Device/Simulator
-  * App version
-* **Additional Context**: Any other relevant information
+Use the issue templates. Include: description, steps to reproduce, expected vs. actual, iOS version, device/simulator, app version, and screenshots where useful.
 
 ## 💡 Suggesting Features
 
-### Feature Request Template
-
-* **Feature Description**: Clear description of the feature
-* **Use Case**: Why is this feature needed?
-* **Proposed Solution**: How should it work?
-* **Alternatives**: Other solutions considered
-* **Additional Context**: Screenshots, mockups, etc.
-
-### Feature Evaluation
-
-Features are evaluated based on:
-
-* Alignment with project goals
-* User value
-* Implementation complexity
-* Maintenance burden
-* Open source compatibility
-
-## 🔍 Code Review Process
-
-1. **Automated Checks**: CI/CD will run basic checks
-2. **Review**: Maintainers will review your PR
-3. **Feedback**: Address any feedback or requested changes
-4. **Approval**: Once approved, your PR will be merged
-
-### Review Criteria
-
-* Code quality and style
-* Architecture adherence
-* Test coverage
-* Documentation
-* Performance considerations
-
-## 📝 Documentation
-
-### Code Documentation
-
-* Document public APIs
-* Explain complex algorithms
-* Add inline comments for non-obvious code
-* Update README for user-facing changes
-
-### Pull Request Documentation
-
-* Describe what changed and why
-* Include screenshots for UI changes
-* Update CHANGELOG.md for user-visible changes
-* Update DEVELOPER.md for architecture changes
-
-## 🧪 Testing
-
-### Manual Testing
-
-* Test on iOS Simulator
-* Test on physical device
-* Test different iOS versions
-* Test edge cases
-
-### Test Checklist
-
-* [ ] App builds without errors
-* [ ] App runs without crashes
-* [ ] New features work as expected
-* [ ] Existing features still work
-* [ ] No performance regressions
-* [ ] UI looks correct on different screen sizes
-
-## 🎯 Good First Issues
-
-Look for issues labeled `good first issue` if you're new to the project. These are:
-
-* Well-defined
-* Small in scope
-* Good learning opportunities
-* Clearly documented
+Explain the use case and how it fits the philosophy. Features are evaluated on user value, alignment with the terminal fantasy, complexity, and maintenance burden — subtraction wins ties.
 
 ## ❓ Getting Help
 
-* **GitHub Discussions**: For questions and discussions
-* **GitHub Issues**: For bugs and feature requests
-* **Code Comments**: Check code comments for implementation details
+* **GitHub Issues** for bugs and feature requests
+* **GitHub Discussions** for questions
+* Check code comments — invariants are documented where they live
 
 ## 📜 License
 
 By contributing, you agree that your contributions will be licensed under the MIT License.
 
-## 🙏 Recognition
-
-Contributors will be:
-
-* Listed in CONTRIBUTORS.md (if we create one)
-* Credited in release notes
-* Acknowledged in the project
-
-## 🚫 What Not to Contribute
-
-* Features that add ads or paywalls
-* Code that compromises user privacy
-* Changes that break the open source nature
-* Features that require closed-source dependencies
-* Code that doesn't follow the project's architecture
-
 ---
 
 **Thank you for contributing to SudoSodoku!** 🎉
-
-Your contributions help make this project better for everyone. We appreciate your time and effort!

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -15,56 +15,46 @@ Welcome! This document provides transparency into SudoSodoku's development proce
 
 ## 🗺️ Feature Roadmap
 
-### Planned Features
+### Planned Features (post-2.0)
 
-1. **Achievement System** 🏅
-2. **Global Leaderboard** 🌍 (Requires Apple Developer features)
-3. **Hint System** 💡
-4. **Tutorial Mode** 📚
-5. **Swift Charts Enhancements** 📊
-6. **iPad Support** 📱 (Deferred)
-7. **macOS Version** 💻
+1. **Hint System** 💡
+2. **Tutorial Mode** 📚
+3. **Swift Charts Enhancements** 📊
+4. **CRT scanlines + vignette** 📺 (#18, deferred from v2.0 by subtraction)
+5. **Mechanical keyboard sounds, opt-in** ⌨️ (#19, deferred from v2.0 by subtraction)
+6. **iPad Support** 📱 (Deferred indefinitely)
+7. **macOS Version** 💻 (Deferred indefinitely)
 8. **Custom Themes** 🎨
 9. **Variant Sudoku** 🔀
 10. **AI Features** 🤖
 
 ### Shipped Features
 
+#### v2.0 — the ladder, the feel, the fantasy
+
+**Status**: Shipped (see [CHANGELOG.md](CHANGELOG.md) `[2.0.0]` for the full list)
+
+- **Achievement system** 🏅 — twelve binary unlocks incl. one secret, Game Center reporting with an offline queue (`AchievementManager`)
+- **Game Center leaderboards** 🌍 — global ELO plus per-difficulty fastest-time boards; guest play fully supported
+- **Hand-crafted-feel generator** — aesthetic clue patterns + per-difficulty technique identity
+- **Completion time tracking** — active-time play clock, personal bests by fastest solve
+- **Streak indicator**, semantic haptics, breach-log loading, matrix-rain victory sequence
+- **Honest statistics** — no win rate in a no-fail game; SOLVED / ELO / FASTEST / HARDEST
+- **One continuous command line** — accumulating `sudo sudosodoku` navigation with a boot-in on launch
+
 #### Detailed Statistics 📊 (v1.0)
 
 **Status**: Shipped (baseline)
 
-- `StatisticsManager` with personal bests, win rate, difficulty distribution, recent completions
+- `StatisticsManager` with personal bests, difficulty distribution, recent completions
 - `StatsView` dashboard
 - Logical efficiency scoring based on undo count
-
-**Future enhancements (v1.1+)**:
-
-- Completion time tracking
-- Swift Charts progress visualization
-- Streak tracking (daily/weekly/monthly)
 
 ### Feature Details
 
 #### 1. Achievement System 🏅
 
-**Priority**: High | **Version**: v1.1 | **Complexity**: Medium
-
-**Features:**
-
-- Completion achievements
-- Difficulty achievements
-- Speed achievements
-- Streak achievements
-- Rating achievements
-- Technique achievements
-
-**Implementation:**
-
-- New `AchievementManager` class
-- Achievement definitions (Codable)
-- Progress tracking
-- Game Center integration
+**Status**: ✅ Shipped in v2.0 — `AchievementManager` + `Achievement` model, twelve binary unlocks (completion counts, first MASTER, zero-undo, sub-3-minute, rank tiers, one secret), Game Center reporting with an offline queue, unlocks rendered inside the victory sequence.
 
 ---
 
@@ -86,21 +76,7 @@ Welcome! This document provides transparency into SudoSodoku's development proce
 
 #### 3. Global Leaderboard 🌍
 
-**Priority**: Medium | **Version**: v1.3 | **Complexity**: High
-
-**Features:**
-
-- ELO leaderboard
-- Category leaderboards
-- Friend rankings
-- Regional rankings
-- Historical rankings
-
-**Requirements:**
-
-- Paid Apple Developer Account
-- Game Center configuration
-- CloudKit setup
+**Status**: ✅ Shipped in v2.0 — Game Center global ELO ranking plus per-difficulty fastest-time boards, terminal-styled `LeaderboardView` (`cat /leaderboard`), `GKAccessPoint` fallback, guest sign-in notice. No CloudKit needed. Friend/regional/historical rankings remain future ideas.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
 # **SudoSodoku**
 
 ```
-$ sudo solve
+root@ios:~$ sudo sudosodoku breach --master
 [sudo] password for logic: ********
-> root access granted.
+> uniqueness_check ........ [OK]
+> difficulty_index ........ 84
+> ACCESS GRANTED
 ```
 
 **`sudo solve` — root access for logical purists.**
 
 SudoSodoku is the only sudoku on the App Store that treats you like root. It is a full terminal fantasy: green phosphor on deep dark glass, mechanical-keyboard haptics, and an ELO ladder that climbs from `SCRIPT_KIDDIE` to `THE_ARCHITECT`. You are not filling in numbers — you are breaching a grid, and every victory ends the only way it should: `ACCESS GRANTED`.
 
+**📱 v2.0.0 · iOS 17.0+ · iPhone · App Store submission in progress**
+
 ## **🧠 Philosophy**
 
 Four rules the whole game is built on:
 
 1. **You're not filling numbers. You're breaching systems.**
-   The terminal fantasy is total. Puzzles generate behind a live breach log (`$ sudo breach --target=grid_9x9`), victories detonate matrix rain, and rank-ups get a ceremony. Every touchpoint speaks shell.
+   The terminal fantasy is total — the app is one continuous shell session. The landing prompt boots in on launch (`root@ios:~$ ` types `sudo sudosodoku` before your eyes), every screen is a subcommand picked from tab completion, puzzles generate behind a live breach log, victories detonate matrix rain, and rank-ups get a ceremony.
 
 2. **Pure logic. Zero noise.**
-   No ads. No lives. No pay-to-win. No guilt mechanics. Even the timer is optional — nothing is allowed to interrupt a deduction.
+   No ads. No lives. No pay-to-win. No guilt mechanics. No fail state — boards are finished or unfinished, never "lost". Even the timer is optional; nothing is allowed to interrupt a deduction.
 
 3. **Earn your rank.**
-   A real ELO system with anti-smurfing (top players gain nothing from stomping easy grids), and Game Center leaderboards that rank actual performance — fastest solves and rating — never spending.
+   A real ELO system with anti-smurfing (top players gain nothing from stomping easy grids), Game Center leaderboards that rank actual performance — fastest solves and rating, never spending — and twelve achievements, one of them secret.
 
 4. **Juice with respect.**
    Rigid-impact keystrokes, phosphor pulses, CRT-glitch error shakes — and every single animation respects Reduce Motion, sounds are never forced on. Delight is a layer, not a tax.
@@ -30,14 +34,17 @@ Four rules the whole game is built on:
 
 ### **🖥️ The Terminal**
 
-* Authentic green phosphor (#00FF00) on deep dark background (#0D121A), all-monospaced UI
+* Authentic green phosphor on deep dark glass (`#0D121A`), all-monospaced UI — from the launch screen (which boots dark, never a white flash) to the last stat card
+* **One accumulating command line**: `breach`, `archives`, `stats`, and `whoami` are subcommands typed into a live prompt; each destination echoes the full command it was reached with (`root@ios:~$ sudo sudosodoku breach --easy`)
 * Typewriter **breach-log loading screen** whose verdict lines report the real uniqueness check and difficulty index of your puzzle
-* Three-act **victory sequence**: Canvas-drawn matrix rain → typewriter `ACCESS GRANTED` → ELO ticker rolling to your new rating, with a glowing `>> RANK_UP <<` ceremony on tier crossings
+* Three-act **victory sequence**: Canvas-drawn matrix rain → typewriter `ACCESS GRANTED` → ELO ticker rolling to your new rating, with a glowing `>> RANK_UP <<` ceremony on tier crossings — and achievement unlocks rendered right inside it
 * A semantic **haptic vocabulary**: cell selection ticks, rigid key-press placements, error notifications, and a custom CoreHaptics victory rumble
+* A one-time surprise waiting in your first MASTER game
 
 ### **♾️ The Grid**
 
-* Real-time procedural generation — unique, human-gradable puzzles with a logical-solver difficulty score (0–100), never a canned database
+* Real-time procedural generation — unique-solution, human-gradable puzzles with a logical-solver difficulty score (0–100), never a canned database
+* **Hand-crafted feel**: clue patterns follow varied aesthetic styles (rotational, mirror, diagonal, or deliberately free), and every difficulty has a technique identity — EASY always offers parallel simple moves and can never dead-end you, MEDIUM never demands more than locked candidates / naked pairs, HARD is designed around a fair intermediate "aha" and never requires guessing, MASTER resists intermediate techniques entirely
 * Four difficulty flags: `--easy` `--medium` `--hard` `--master`
 * Pencil notes with **auto-clear**: placing a digit sweeps it from peer notes, and undo restores everything as one compound move
 * Numpad that thinks: exhausted digits strike through, dead taps nudge instead of being swallowed, the selection frame glides between cells
@@ -47,72 +54,70 @@ Four rules the whole game is built on:
 
 * ELO rating from 1200 with adaptive K-factor and anti-smurfing
 * Six ranks: `SCRIPT_KIDDIE` → `USER` → `SUDOER` → `SYS_ADMIN` → `KERNEL_HACKER` → `THE_ARCHITECT`
-* **Game Center leaderboards**: a global ELO ranking plus fastest-time boards per difficulty (`cat /leaderboard`)
-* Personal bests, logical-efficiency scoring, and full session archives with favorites and replay
+* **Game Center leaderboards**: a global ELO ranking plus fastest-time boards per difficulty (`cat /leaderboard`) — playable fully offline as a guest
+* **Twelve achievements** (`HELLO_WORLD` … `THE_ARCHITECT`), all binary unlocks, one secret
+* Honest statistics for a no-fail game (SOLVED / ELO / FASTEST / HARDEST — no fake "win rate"), personal bests, and full session archives where solved runs are immutable history: restarts fork a fresh attempt, viewing an old solution never rewrites it
 
 ## **🛠️ Technical Architecture**
 
 * **Language**: Swift 5.9 · **UI**: SwiftUI · **Pattern**: MVVM · **State**: Combine
 * **Platform**: iPhone-only, iOS 17.0+
-* **Persistence**: single local JSON file, atomic writes, versioned migration chain
-* **Game services**: GameKit (auth, leaderboards) · CoreHaptics
-* **Testing**: `SudoSodokuTests` unit suite (generator, rating, storage, gameplay logic) run locally and on Xcode Cloud
+* **Persistence**: single local JSON file, atomic writes, versioned migration chain — everything stays on device
+* **Game services**: GameKit (optional auth, leaderboards, achievements) · CoreHaptics
+* **Testing**: `SudoSodokuTests` unit suite (generator quality, rating, storage, record immutability, gameplay logic) run locally and on Xcode Cloud
 
 ### **Directory Structure**
 
 ```
 SudoSodoku/
 ├── SudoSodokuApp.swift           # @main entry
-├── Models/                       # GameRecord, SudokuCell, MoveHistory, Difficulty, RankTier, ...
+├── Models/                       # GameRecord, SudokuCell, MoveHistory, Difficulty, RankTier, Achievement, ...
 ├── ViewModels/
-│   └── SudokuGame.swift          # Core game logic, play clock, undo/redo, conflict signals
+│   └── SudokuGame.swift          # Core game logic, play clock, undo/redo, victory pipeline
 ├── Managers/
 │   ├── GameCenterManager.swift   # Auth + leaderboard submissions
+│   ├── AchievementManager.swift  # Unlock evaluation, local persistence, offline report queue
 │   ├── RatingManager.swift       # ELO calculation
 │   ├── HapticManager.swift       # Semantic haptic vocabulary (+ CoreHaptics victory)
 │   ├── StatisticsManager.swift   # Stats aggregation
 │   └── StorageManager.swift      # Atomic JSON persistence + migrations
 ├── Algorithms/
-│   └── SudokuGenerator.swift     # Backtracking generation + logical difficulty grading
+│   └── SudokuGenerator.swift     # Generation, uniqueness, technique tiers, difficulty grading
 ├── Utils/                        # AppConstants (leaderboard IDs), DateFormatting, ...
 └── Views/
     ├── GameView.swift            # The board screen
     ├── LeaderboardView.swift     # Terminal-styled Game Center rankings
     ├── ...                       # Landing, Archive, Stats, Profile, ModeSelection
-    └── Components/               # BreachLogView, MatrixVictoryOverlay, CellView, ...
+    └── Components/               # TerminalCommandComposer, BreachLogView, MatrixVictoryOverlay, ...
 
+Config/Info.plist                 # Launch screen keys merged into the generated Info.plist
 SudoSodokuTests/                  # Unit tests (picked up automatically by the shared scheme)
 ```
 
 ## **🚀 Building the Project**
 
-### **Method 1: Using Xcode (Traditional)**
+### **Method 1: Using Xcode**
 
 1. **Clone the repository**:
 
-  ```bash
-  git clone https://github.com/kaiiiichen/SudoSodoku.git
-  ```
+   ```bash
+   git clone https://github.com/kaiiiichen/SudoSodoku.git
+   ```
 
-1. **Open in Xcode**:
-   Double-click `SudoSodoku.xcodeproj`. Ensure you have Xcode 15.0+ installed.
+2. **Open in Xcode**:
+   Double-click `SudoSodoku.xcodeproj`. Xcode 15.0+ required.
 
-2. **Configure Signing**:
-   * Go to the Project Navigator (blue icon).
-   * Select the SudoSodoku target.
-   * Click **Signing & Capabilities**.
-   * Change the **Team** to your own Apple Developer account.
+3. **Configure Signing**:
+   Select the SudoSodoku target → **Signing & Capabilities** → set your own Team.
 
-3. **Run**:
+4. **Run**:
    Connect your iPhone or select a Simulator and press `Cmd + R`.
 
-### **Method 2: Using Command Line (Cursor/VS Code)**
+> ⚠️ If Xcode suggests "Update to recommended settings", decline the change that rewrites `IPHONEOS_DEPLOYMENT_TARGET` — it must stay the literal `17.0` (see [CONTRIBUTING.md](CONTRIBUTING.md)).
 
-We provide convenient build scripts for command-line development:
+### **Method 2: Command Line**
 
-#### **Build Scripts**
-
-* **`build.sh`** - Build the project (similar to Xcode's Cmd+B)
+* **`build.sh`** — build the project (like Xcode's Cmd+B)
 
   ```bash
   ./build.sh          # Debug build (default)
@@ -120,53 +125,48 @@ We provide convenient build scripts for command-line development:
   ./build.sh clean    # Clean build artifacts
   ```
 
-* **`play.sh`** - Build and run in iOS Simulator
+* **`play.sh`** — build and run in the iOS Simulator
 
   ```bash
   ./play.sh
   ```
 
-#### **Running Tests**
+* **Tests**:
 
-```bash
-xcodebuild test -project SudoSodoku.xcodeproj -scheme SudoSodoku \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
-```
+  ```bash
+  xcodebuild test -project SudoSodoku.xcodeproj -scheme SudoSodoku \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+  ```
 
 ### **Build Requirements**
 
-* macOS 13.0+ (for iOS development)
-* Xcode 15.0+ with Command Line Tools
-* iOS 17.0+ deployment target
-* iPhone only (portrait and landscape)
+* macOS 13.0+ · Xcode 15.0+ with Command Line Tools
+* iOS 17.0+ deployment target · iPhone only
 
 ## **🤝 Contributing**
 
-Contributions are welcome! We appreciate your help in making SudoSodoku better.
+Contributions are welcome! Start with the [Contributing Guidelines](CONTRIBUTING.md) — they document this repo's actual workflow, not boilerplate:
 
-**Getting Started:**
+* All changes go through feature branches and pull requests — never direct commits to `main`
+* Conventional Commits, and `CHANGELOG.md` updated in the same PR
+* The full test suite must pass before every PR; new generator/rating/storage logic needs matching unit tests
+* iPhone-only scope: no iPad or macOS work
+* UI copy speaks terminal (monospaced, `UPPER_SNAKE`, shell-flavored strings); every animation respects Reduce Motion, sounds are never forced on
 
-1. Read our [Contributing Guidelines](CONTRIBUTING.md)
-2. Check our [Code of Conduct](CODE_OF_CONDUCT.md)
-3. Look for issues labeled `good first issue`
-4. Fork, make changes, and submit a Pull Request
-
-All changes go through feature branches and pull requests — never direct commits to `main`. Update `CHANGELOG.md` in the same PR, and keep new generator/rating/storage logic covered by unit tests.
-
-### **Code Style Guidelines**
-
-* All code comments and documentation in English
-* Follow Swift naming conventions and the MVVM architecture
-* Match the terminal aesthetic in UI copy (monospaced, `UPPER_SNAKE` labels, shell-flavored strings)
-* Every animation must respect Reduce Motion; sounds are never forced on
+Also see the [Code of Conduct](CODE_OF_CONDUCT.md) and issues labeled `good first issue`.
 
 ## **📚 Additional Documentation**
 
-* **[CHANGELOG.md](CHANGELOG.md)** - Version history and release notes
-* **[DEVELOPER.md](DEVELOPER.md)** - Feature roadmap, testing checklist, and development guidelines
-* **[CONTRIBUTING.md](CONTRIBUTING.md)** - Guidelines for contributing to the project
-* **[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)** - Community code of conduct
-* **[SECURITY.md](.github/SECURITY.md)** - Security policy and vulnerability reporting
+* **[CHANGELOG.md](CHANGELOG.md)** — Version history
+* **[RELEASE_NOTES_v2.0.0.md](RELEASE_NOTES_v2.0.0.md)** — What shipped in 2.0
+* **[DEVELOPER.md](DEVELOPER.md)** — Roadmap, testing checklist, and development guidelines
+* **[CONTRIBUTING.md](CONTRIBUTING.md)** — How to contribute
+* **[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)** — Community code of conduct
+* **[SECURITY.md](.github/SECURITY.md)** — Security policy and vulnerability reporting
+
+## **🔒 Privacy**
+
+Your data never leaves your device: game history, rating, and achievements live in a single local JSON file. There is no analytics, no tracking, and no account — Game Center sign-in is optional and only powers the leaderboards. See the [security policy](.github/SECURITY.md) for details.
 
 ## **📄 License**
 

--- a/RELEASE_NOTES_v2.0.0.md
+++ b/RELEASE_NOTES_v2.0.0.md
@@ -27,10 +27,16 @@ v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a fu
 - An optional play clock that only counts active time; personal bests and archives show durations.
 - Every animation respects Reduce Motion. Sounds are never forced on.
 
+## The whole app is one command line ⌨️
+
+- Navigation reads as a single accumulating shell session: the landing terminal boots in (`root@ios:~$ ` types `sudo sudosodoku` on launch), picking `breach`, `archives`, `stats`, or `whoami` types the subcommand into the prompt, and every screen echoes the full command it was reached with.
+- Even the launch screen speaks terminal: the first frame after install boots in the phosphor-dark background instead of a white flash.
+
 ## Fixed
 
 - EASY boards can no longer stall you: the grader now understands column/box logic, clue distribution is guaranteed, and every step offers at least two ways forward.
 - Profile statistics stay in lockstep with your archive (previously they lagged by one change).
+- Your history is safe: restarting or replaying a solved puzzle forks a fresh attempt instead of overwriting the completed run, and viewing an old solution no longer bumps its date.
 
 ---
 


### PR DESCRIPTION
## Summary

Final repo-side preparation for the v2.0.0 App Store submission — the last item on the path to [#21](https://github.com/kaiiiichen/SudoSodoku/issues/21) that lives in the repo rather than App Store Connect.

- **CHANGELOG.md** — `[Unreleased]` folded into `[2.0.0]`: the version was never published, so the archive Kai submits and the changelog now tell the same story (CLI navigation #47, `sudo sudosodoku` branding #51, boot-in #54, dark launch screen, solved-record immutability #56). `[Unreleased]` is intentionally left empty for the release; this PR's own change *is* the changelog work.
- **RELEASE_NOTES_v2.0.0.md** — picks up the post-cut work (one-command-line navigation, dark launch, history-safety fixes).
- **README.md** — rewritten to match the shipped app: the real `root@ios:~$ sudo sudosodoku` hero, the accumulating command-line navigation and boot-in, achievements, honest stats, immutable archives, a Privacy section, and an availability line (no fake App Store link — it says "submission in progress").
- **CONTRIBUTING.md** — template boilerplate replaced with this repo's actual rules: never commit to `main`, changelog in the same PR, the exact test-gate command, synchronized folder groups (don't hand-register files in pbxproj), the literal `17.0` deployment-target pin (Xcode Cloud breaks otherwise), iPhone-only scope, terminal-copy + Reduce Motion requirements, and the data-integrity invariants (solved records immutable, decode defaults for new fields, stats derive from emitted values).
- **.github/SECURITY.md** — supported versions 2.0.x; the privacy story stated precisely (single local JSON, no analytics/tracking/accounts, Game Center optional and never presented at launch).
- **DEVELOPER.md** — roadmap de-staled: Achievements and Global Leaderboards marked shipped in v2.0 with what actually shipped; deferred C-tier items (#18, #19) listed as post-2.0 with their issue numbers.

## Verification

- Stale-reference scan: no `sudo sodoku`, no `win rate`, no 1.0.x versions remain in the touched docs; all relative links resolve
- `xcodebuild test` on iPhone 17 Pro simulator: **84/84 passed**

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)