### PR TITLE
fix: overlong commands wrap as one continuous terminal line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a fu
 
 ### Fixed
 
+- Overlong terminal commands (e.g. `sudo sudosodoku breach --easy`) shattered into stacked fragments: the prompt was an HStack of separate Texts, so each segment wrapped inside its own bounds and got centered against the others. The command line is now one concatenated Text that wraps as a single continuous flow, like a real shell; the caret blinks hard on/off instead of fading (#60)
 - Solved records are now immutable history: restarting a solved puzzle from the archive (`sudo reboot`) or the in-game RETRY forked in place under the same record id, so the first autosave overwrote the completed run — the solve silently vanished from SOLVED counts, personal bests, and recent completions while the ELO it granted remained. Both paths now fork a fresh record; the original solve stays (#56)
 - Viewing a solved record (`cat solution`) re-saved it with a fresh `lastPlayedTime`, so merely looking at an old solve bumped it to today and reshuffled the archive order. Viewing is read-only now (#56)
 - First launch after install stared at a pale white screen until the first frame arrived: the auto-generated launch screen uses `systemBackground` (white in light mode) while the app itself is always dark. The launch screen now boots in the terminal background color, and the Game Center handshake waits a beat past the first frame so GameKit's first-run spin-up doesn't compete with the initial render

--- a/SudoSodoku/Views/Components/ExecutedCommandLine.swift
+++ b/SudoSodoku/Views/Components/ExecutedCommandLine.swift
@@ -7,10 +7,11 @@ struct ExecutedCommandLine: View {
     let command: String
 
     var body: some View {
-        HStack(spacing: 0) {
-            Text("root@ios:~$ ").foregroundColor(.green)
-            Text(command).foregroundColor(.white)
-        }
-        .font(.system(size: 14, weight: .bold, design: .monospaced))
+        // Concatenated so an overlong command wraps as one continuous
+        // leading-aligned flow, not as fragments centered against each
+        // other (see TerminalCommandComposer.commandLine).
+        (Text("root@ios:~$ ").foregroundColor(.green)
+            + Text(command).foregroundColor(.white))
+            .font(.system(size: 14, weight: .bold, design: .monospaced))
     }
 }

--- a/SudoSodoku/Views/Components/TerminalCommandComposer.swift
+++ b/SudoSodoku/Views/Components/TerminalCommandComposer.swift
@@ -56,10 +56,16 @@ struct TerminalCommandComposer<Hero: View>: View {
         }
         .padding(.horizontal)
         .onAppear {
-            withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
-                cursorVisible = false
-            }
             if isBooting { bootIn() }
+        }
+        .task {
+            // Hard on/off blink, like a real terminal caret. (The old fade
+            // relied on animating .opacity, which the concatenated command
+            // line can't express per-segment.)
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(600))
+                cursorVisible.toggle()
+            }
         }
     }
 
@@ -70,17 +76,23 @@ struct TerminalCommandComposer<Hero: View>: View {
             Text(awaitingComment)
                 .font(.system(size: 12, design: .monospaced))
                 .foregroundColor(.gray)
-            HStack(spacing: 0) {
-                Text("root@ios:~$ ").foregroundColor(.green)
-                Text(isBooting ? typedBase : baseCommand + " ").foregroundColor(.white)
-                Text(typedSuffix).foregroundColor(pickedOption?.color ?? .green)
-                Text("_")
-                    .foregroundColor(.green)
-                    .opacity(cursorVisible ? 1 : 0)
-            }
-            .font(.system(size: 17, weight: .bold, design: .monospaced))
+            commandLine
+                .font(.system(size: 17, weight: .bold, design: .monospaced))
         }
         .padding(.top, 24)
+    }
+
+    /// One concatenated Text, not an HStack of Texts: an overlong command
+    /// must wrap as a single continuous flow onto the next line (the way a
+    /// real terminal wraps). Separate Texts each wrap inside their own
+    /// bounds and get centered against each other - the command shatters
+    /// into stacked fragments. The cursor blinks by color (green/clear)
+    /// because view modifiers like .opacity can't target a segment.
+    private var commandLine: Text {
+        Text("root@ios:~$ ").foregroundColor(.green)
+            + Text(isBooting ? typedBase : baseCommand + " ").foregroundColor(.white)
+            + Text(typedSuffix).foregroundColor(pickedOption?.color ?? .green)
+            + Text("_").foregroundColor(cursorVisible ? .green : .clear)
     }
 
     private var completionSection: some View {


### PR DESCRIPTION
## Problem

Reported by Kai with device screenshots: after the `sudo sudosodoku` rename, prompt lines routinely exceed one line and shatter into stacked fragments — `sudo sudosodoku` wrapped over `breach` inside one block with `--easy_` floating vertically centered beside it. Nothing like how a real terminal wraps.

## Root cause

`TerminalCommandComposer.commandSection` and `ExecutedCommandLine` composed the command as an `HStack(spacing: 0)` of separate `Text` views. Each `Text` wraps independently inside its own bounds, and the HStack centers the fragments against each other.

## Fix

- The command line is now a **single concatenated `Text`** (`Text + Text` preserves per-segment colors), so an overlong command wraps as one continuous, leading-aligned flow onto the next line — the way a shell wraps. Applied to both the composer prompt and `ExecutedCommandLine`'s echoed breadcrumbs.
- The caret now blinks hard on/off via a green/clear color toggle driven by a timer: `.opacity()` is a view modifier and can't target a segment inside a concatenation — and a hard blink is more terminal-authentic than the old fade anyway.

## Verification

- Harness screenshot on the iPhone 17 Pro simulator with deliberately overlong commands: `root@ios:~$ sudo sudosodoku breach` flows onto `--master` on line two, leading-aligned, caret at the end; `ExecutedCommandLine` wraps identically. No fragments, no vertical centering.
- `xcodebuild test`: **84/84 passed**.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)