### PR TITLE
fix: caret respects Reduce Motion; playClock is nonisolated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Command-line caret stays solid under Reduce Motion instead of blinking; `DateFormatting.playClock` is now `nonisolated`, silencing the main-actor warning in StatsView (#64)
+
 ---
 
 ## [2.0.0] - 2026-07-08

--- a/SudoSodoku/Utils/DateFormatting.swift
+++ b/SudoSodoku/Utils/DateFormatting.swift
@@ -8,7 +8,9 @@ enum DateFormatting {
     }()
 
     /// Terminal-style play clock: "00:12:34" (hours shown only when nonzero: "1:02:03").
-    static func playClock(_ interval: TimeInterval) -> String {
+    /// Pure computation — nonisolated so it can be passed as a function value
+    /// (e.g. to `Optional.map`) without tripping main-actor isolation.
+    nonisolated static func playClock(_ interval: TimeInterval) -> String {
         let total = max(0, Int(interval))
         let hours = total / 3600
         let minutes = (total % 3600) / 60

--- a/SudoSodoku/Views/Components/TerminalCommandComposer.swift
+++ b/SudoSodoku/Views/Components/TerminalCommandComposer.swift
@@ -61,7 +61,8 @@ struct TerminalCommandComposer<Hero: View>: View {
         .task {
             // Hard on/off blink, like a real terminal caret. (The old fade
             // relied on animating .opacity, which the concatenated command
-            // line can't express per-segment.)
+            // line can't express per-segment.) Solid under Reduce Motion.
+            guard !reduceMotion else { return }
             while !Task.isCancelled {
                 try? await Task.sleep(for: .milliseconds(600))
                 cursorVisible.toggle()


### PR DESCRIPTION
## Summary

- The command-line caret in `TerminalCommandComposer` blinked unconditionally; it now stays solid under Reduce Motion, per the project rule that every animation respects it.
- `DateFormatting.playClock` is pure computation but was implicitly `@MainActor` (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`), so passing it as a function value to `Optional.map` in StatsView emitted a main-actor isolation warning. Marked `nonisolated` — all call sites unchanged.

Closes #64

## Testing

- `xcodebuild test` (iPhone 17 Pro simulator): all tests pass, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)