### PR TITLE
fix: Game Center sign-in must not re-flow the landing layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Game Center sign-in no longer jolts the landing screen: the identity row renders every auth state in a fixed 30×30 avatar slot with a constant row height, so authentication swaps pixels in place instead of re-flowing the layout (#66)
+
 ---
 
 ## [2.0.0] - 2026-07-08

--- a/SudoSodoku/Views/LandingView.swift
+++ b/SudoSodoku/Views/LandingView.swift
@@ -67,20 +67,30 @@ struct LandingView: View {
     // MARK: - Sections
 
     private var identityRow: some View {
+        // Every auth state renders in the same fixed 30x30 avatar slot with a
+        // constant row height: signing in must swap pixels in place, never
+        // re-flow the layout under the whole screen.
         HStack {
-            if gcManager.isAuthenticated {
-                if let photo = gcManager.playerPhoto {
-                    photo.resizable().scaledToFit().frame(width: 30, height: 30).clipShape(Circle()).overlay(Circle().stroke(Color.green, lineWidth: 1))
+            Group {
+                if gcManager.isAuthenticated {
+                    if let photo = gcManager.playerPhoto {
+                        photo.resizable().scaledToFit()
+                            .clipShape(Circle())
+                            .overlay(Circle().stroke(Color.green, lineWidth: 1))
+                    } else {
+                        Image(systemName: "person.circle.fill").resizable().scaledToFit().foregroundColor(.green)
+                    }
                 } else {
-                    Image(systemName: "person.circle.fill").font(.system(size: 30)).foregroundColor(.green)
+                    Image(systemName: "person.circle").resizable().scaledToFit().foregroundColor(.gray)
                 }
-                Text("user: \(gcManager.playerName)").font(.system(size: 14, design: .monospaced)).foregroundColor(.green)
-            } else {
-                Image(systemName: "person.circle").font(.system(size: 30)).foregroundColor(.gray)
-                Text("user: guest").font(.system(size: 14, design: .monospaced)).foregroundColor(.gray)
             }
+            .frame(width: 30, height: 30)
+            Text("user: \(gcManager.isAuthenticated ? gcManager.playerName : "guest")")
+                .font(.system(size: 14, design: .monospaced))
+                .foregroundColor(gcManager.isAuthenticated ? .green : .gray)
             Spacer()
         }
+        .frame(height: 30)
         .padding(.top, 50).padding(.horizontal)
     }
 


### PR DESCRIPTION
## Summary

On device, when Game Center authentication completed (~1s after launch), the whole landing screen jolted and shifted. The identity row rendered each auth state at a different height — guest/authenticated SF symbols are sized by font line height (~36pt) while the loaded player photo is a fixed 30×30 — and the swap happens in two un-animated steps (auth flips, then the photo arrives), each re-flowing everything below the row.

The row now renders every auth state in the same fixed 30×30 avatar slot with a constant row height: signing in swaps pixels in place and the layout never moves.

Closes #66

## Testing

- `xcodebuild test` (iPhone 17 Pro simulator): all tests pass.
- Verified on device by Kai: sign-in no longer nudges the layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)