### PR TITLE
fix: hero glow pulse survives navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The landing hero's glow pulse survives navigation: it restarts on every return to the landing screen instead of freezing dim after the first push; steady full glow under Reduce Motion (#68)
+
 ---
 
 ## [2.0.0] - 2026-07-08

--- a/SudoSodoku/Views/LandingView.swift
+++ b/SudoSodoku/Views/LandingView.swift
@@ -14,6 +14,7 @@ struct LandingView: View {
     @State private var bootsIn = true
     @State private var hasAppearedBefore = false
     @ObservedObject var gcManager = GameCenterManager.shared
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         ZStack {
@@ -92,6 +93,12 @@ struct LandingView: View {
                 .shadow(color: .green.opacity(glowStrength), radius: 15)
                 .shadow(color: .green.opacity(glowStrength * 0.6), radius: 40)
                 .onAppear {
+                    // repeatForever animations die when a pushed screen covers
+                    // this view; on the way back, animating to the value the
+                    // state already holds is a no-op and the glow froze dim.
+                    // Reset without animation, then restart the pulse.
+                    glowStrength = 1.0
+                    guard !reduceMotion else { return }
                     withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
                         glowStrength = 0.4
                     }


### PR DESCRIPTION
## Summary

On first launch the landing hero title pulses its glow, but after pushing into any screen and popping back the pulse was gone — the title sat frozen at its dim value.

`repeatForever` animations are removed when a pushed screen covers the view; on the way back, `onAppear` re-animated `glowStrength` to the value it already held (0.4), which is a no-op, so nothing restarted. The fix resets the state to 1.0 without animation on every appearance and then restarts the pulse. While here, the pulse now respects Reduce Motion (steady full glow, no pulsing), per the project animation rule — it previously pulsed unconditionally.

`BreachLogView` and `MatrixVictoryOverlay` use the same `repeatForever`-in-`onAppear` pattern but are recreated fresh on every presentation, so they don't have this bug.

Closes #68

## Testing

- `xcodebuild test` (iPhone 17 Pro simulator): all tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)