### PR TITLE
docs: restore #64 changelog entry lost in merge-conflict resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The landing hero's glow pulse survives navigation: it restarts on every return to the landing screen instead of freezing dim after the first push; steady full glow under Reduce Motion (#68)
 - Game Center sign-in no longer jolts the landing screen: the identity row renders every auth state in a fixed 30×30 avatar slot with a constant row height, so authentication swaps pixels in place instead of re-flowing the layout (#66)
+- Command-line caret stays solid under Reduce Motion instead of blinking; `DateFormatting.playClock` is now `nonisolated`, silencing the main-actor warning in StatsView (#64)
 
 ---
 


### PR DESCRIPTION
## Summary

The `[Unreleased] > Fixed` entry added by PR #65 —

> Command-line caret stays solid under Reduce Motion instead of blinking; `DateFormatting.playClock` is now `nonisolated`, silencing the main-actor warning in StatsView (#64)

— was dropped from `CHANGELOG.md` during merge-conflict resolution in a later PR. This re-adds it alongside the #66/#68 entries. Docs-only, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)