### PR TITLE
docs: require a label on every GitHub issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,9 @@
   Kai mirrors GitHub issues into Linear — keep issue state accurate.
 - **Assign every new issue to `kaiiiichen`** (sole owner; there is no other
   agent/boss account).
+- **Every issue must carry at least one label.** Pick from the repo's existing
+  labels (`bug`, `enhancement`, `feature`, `documentation`, `game-center`,
+  `ux-*`, `release`, …); create a new label only when none fits.
 
 ## Project Facts
 


### PR DESCRIPTION
## Summary

Codifies the workflow rule in `CLAUDE.md` > Git Workflow: **every issue must carry at least one label**, picked from the repo's existing label set (create a new label only when none fits). Complements the existing "assign every new issue to kaiiiichen" rule; labels keep the GitHub → Linear mirror triageable.

All 16 previously unlabeled issues (open and closed) have already been backfilled with labels.

Docs-only change; no changelog entry (agent-workflow guideline, not app behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)