### PR TITLE
fix: reserve a two-line slot for the composed command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- An overlong composed command no longer shoves the layout around: the terminal command line reserves a two-line slot up front, so wrapping happens inside it and the hero, tagline, and completion menu stay put on the landing and mode-selection screens (#78)
 - Stats no longer judge solves by undo count anywhere: personal best rows drop UNDOS/QUALITY for date set and rating gain, recent completions show the solve time instead of the undo-derived EFF score, and the legacy personal-best fallback (pre-time-tracking records) picks the most recent solve instead of the fewest undos; the dead `logicalEfficiency`/`logicalQuality` metrics are removed (#77)
 - The landing hero's glow pulse survives navigation: it restarts on every return to the landing screen instead of freezing dim after the first push; steady full glow under Reduce Motion (#68)
 - Game Center sign-in no longer jolts the landing screen: the identity row renders every auth state in a fixed 30×30 avatar slot with a constant row height, so authentication swaps pixels in place instead of re-flowing the layout (#66)

--- a/SudoSodoku/Views/Components/TerminalCommandComposer.swift
+++ b/SudoSodoku/Views/Components/TerminalCommandComposer.swift
@@ -77,8 +77,17 @@ struct TerminalCommandComposer<Hero: View>: View {
             Text(awaitingComment)
                 .font(.system(size: 12, design: .monospaced))
                 .foregroundColor(.gray)
-            commandLine
-                .font(.system(size: 17, weight: .bold, design: .monospaced))
+            // The command line owns a two-line slot up front: a hidden
+            // two-line template sizes the frame, so an overlong composed
+            // command wraps inside reserved space instead of growing the
+            // section and shoving the hero and menu below it (#78). A
+            // template, not a magic number, so the slot tracks the font's
+            // real line metrics.
+            ZStack(alignment: .topLeading) {
+                Text(" \n ").hidden()
+                commandLine
+            }
+            .font(.system(size: 17, weight: .bold, design: .monospaced))
         }
         .padding(.top, 24)
     }


### PR DESCRIPTION
## Summary

Closes #78. When the composed command (`root@ios:~$ sudo sudosodoku archives_`) exceeded one line at 17pt bold monospaced, it wrapped — and because the command section sits above the hero in the composer's VStack, the hero, tagline, and completion menu all jumped down mid-typing.

The command line now owns a **two-line slot from the start**: a hidden `Text(" \n ")` template sizes the frame (a template, not a magic height, so it tracks the font's real line metrics), and the live command renders top-leading inside it. Wrapping happens within the reserved space; nothing else on the screen moves. Same swap-pixels-in-place principle as #66.

The fix lives in the shared `TerminalCommandComposer`, so both the landing screen and mode selection (`sudo breach --master` also wraps on narrow devices) are covered.

## Notes

- Longest composable command is ~38 monospaced characters — two lines is enough on every iPhone width; no `lineLimit` clamp, so a hypothetical third line would grow the frame rather than truncate.
- Layout-only change; no logic touched. Full test suite: **TEST SUCCEEDED** on iPhone 17 Pro simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)