### PR TITLE
fix: reset the command composer on the navigation binding, not onAppear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Swiping back right after picking a tab-completion option no longer strands the screen: composer reset now keys off the navigation binding (which always clears on pop) instead of `onAppear` (which never fires when the pop lands mid-push-transition), so the landing and mode-selection screens can't come back with a stale command and every option dead (#79)
 - An overlong composed command no longer shoves the layout around: the terminal command line reserves a two-line slot up front, so wrapping happens inside it and the hero, tagline, and completion menu stay put on the landing and mode-selection screens (#78)
 - Stats no longer judge solves by undo count anywhere: personal best rows drop UNDOS/QUALITY for date set and rating gain, recent completions show the solve time instead of the undo-derived EFF score, and the legacy personal-best fallback (pre-time-tracking records) picks the most recent solve instead of the fewest undos; the dead `logicalEfficiency`/`logicalQuality` metrics are removed (#77)
 - The landing hero's glow pulse survives navigation: it restarts on every return to the landing screen instead of freezing dim after the first push; steady full glow under Reduce Motion (#68)

--- a/SudoSodoku/Views/Components/TerminalCommandComposer.swift
+++ b/SudoSodoku/Views/Components/TerminalCommandComposer.swift
@@ -15,6 +15,13 @@ struct CommandOption: Identifiable {
 /// caller (typically to navigate onward with the composed command as the
 /// next screen's prefix). Shared by every screen that wants navigation to
 /// read as one continuous, accumulating shell session instead of taps.
+///
+/// Caller contract: composing is one-way — after `onExecute`, the composer
+/// stays locked (options disabled, subcommand on the prompt) until the
+/// caller rebuilds it with a fresh `.id`. Rebuild when the navigation
+/// binding returns to nil (`.onChange`), not only in `onAppear`: a
+/// swipe-back that lands mid-push-transition never fires `onAppear`, and
+/// a stale composer deadlocks its whole screen (#79).
 struct TerminalCommandComposer<Hero: View>: View {
     let awaitingComment: String
     let baseCommand: String

--- a/SudoSodoku/Views/LandingView.swift
+++ b/SudoSodoku/Views/LandingView.swift
@@ -63,6 +63,19 @@ struct LandingView: View {
             hasAppearedBefore = true
             composerKey = UUID()
         }
+        .onChange(of: launchTarget) { _, newValue in
+            // A swipe-back that lands before the push transition settles
+            // returns here without this view ever leaving the hierarchy, so
+            // onAppear does not fire again and the composer stays stranded
+            // mid-composition: isComposing forever true, every option
+            // disabled, the picked subcommand stuck on the prompt (#79).
+            // The navigation binding, unlike onAppear, always nils on pop —
+            // reset on it. bootsIn too: any return from navigation is past
+            // the once-per-process boot (#54).
+            guard newValue == nil else { return }
+            bootsIn = false
+            composerKey = UUID()
+        }
     }
 
     // MARK: - Sections

--- a/SudoSodoku/Views/ModeSelectionView.swift
+++ b/SudoSodoku/Views/ModeSelectionView.swift
@@ -44,5 +44,13 @@ struct ModeSelectionView: View {
             // when returning from a finished game.
             composerKey = UUID()
         }
+        .onChange(of: launchDifficulty) { _, newValue in
+            // Same lifecycle gap as the landing screen (#79): a fast
+            // swipe-back can return here without firing onAppear, stranding
+            // the composer with every difficulty row disabled. The
+            // navigation binding always nils on pop — reset on it.
+            guard newValue == nil else { return }
+            composerKey = UUID()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #79. Repro: tap a tab-completion option, then swipe back from the left edge before the push transition settles. The landing screen came back with the picked subcommand stuck on the prompt and **every option permanently disabled** — the whole app deadlocked.

### Root cause
`TerminalCommandComposer.pick()` sets `isComposing = true` and never resets it; recovery relied on the caller's `onAppear` regenerating the composer's `.id`. But a pop that lands mid-push-transition returns without the view ever leaving the hierarchy, so `onAppear` never refires and the stale composer survives.

### Fix
Reset on the thing that is *guaranteed* to change: the `navigationDestination(item:)` binding, which NavigationStack always nils on pop, transition races included.

- **LandingView**: `.onChange(of: launchTarget)` → on nil, regenerate `composerKey` and drop `bootsIn` (otherwise this path would replay the once-per-process boot animation, regressing #54). `onAppear` reset kept as belt-and-braces.
- **ModeSelectionView**: same trap (pick difficulty → GameView → fast swipe-back → all difficulty rows dead), same fix on `launchDifficulty`.
- **TerminalCommandComposer**: caller contract documented — rebuild on the navigation binding, not only `onAppear`.

Path walkthrough: normal pop (onAppear + onChange both reset, idempotent) ✓ · fast swipe-back (onChange resets) ✓ · cancelled swipe staying on destination (binding untouched, no spurious reset) ✓ · mid-typing (binding never transitions to nil) ✓. Bonus: the rebuilt composer re-fires the hero's `onAppear`, so the #68 glow restart is covered on this return path too.

## Verification

- Full suite (85 tests) run **6×** total (`-test-iterations 3 -run-tests-until-failure` + 3 clean runs): all green, zero flakes.
- App built, installed, and launched in the iPhone 17 Pro simulator; landing screen verified by screenshot (boot types in, menu materializes, two-line command slot intact).
- ⚠️ The interactive-pop race itself is a hand gesture — this machine has no Simulator UI or gesture-injection tooling, so **please verify the repro on device**: tap `archives`, swipe back immediately during the push, confirm the prompt resets and options stay live (repeat a few times; also from mode selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)