### PR TITLE
feat: condense the slogan to 'sudo solve — logic is root access'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2026-07-08
 
-### 🚀 sudo solve — root access for logical purists
+### 🚀 sudo solve — logic is root access
 
 v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a full terminal fantasy with a real competitive ladder. Game Center leaderboards and achievements go live, every puzzle now reads as hand-crafted, and the whole game got a feel pass — haptics, signature moments, and accessibility discipline throughout.
 
@@ -39,7 +39,7 @@ v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a fu
 - Streak indicator: five or more consecutive conflict-free placements show `streak: N ▲` in the game header; a conflict resets it silently (#17)
 - `SudoSodokuTests` unit test target covering puzzle generation (solvability, unique solution, difficulty scoring), ELO rating (K-factor tiers, anti-smurfing), and storage (persistence roundtrip, legacy save migration)
 - Shared `SudoSodoku` scheme with test action, enabling `xcodebuild test` and Xcode Cloud test workflows
-- Product identity: slogan "sudo solve — root access for logical purists", four-pillar philosophy in the README, and the tagline on the landing screen
+- Product identity: slogan "sudo solve — logic is root access" (#93), four-pillar philosophy in the README, and the tagline on the landing screen
 - Public privacy policy (`PRIVACY.md`), written against App Review Guideline 5.1.1(i) and Apple's App Privacy Details guidance: all game data is local-only, the sole online service is Apple-operated Game Center, no analytics/ads/tracking; linked from the README and used as the App Store privacy policy URL (#90)
 - Debug builds only: `$ rm -rf /user_data` factory reset in the profile (records, rating, achievements, sudoers-joke flag, and Game Center achievement progress via `resetAchievements`) for verifying first-run flows; compiled out of Release
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ root@ios:~$ sudo sudosodoku breach --master
 > ACCESS GRANTED
 ```
 
-**`sudo solve` — root access for logical purists.**
+**`sudo solve` — logic is root access.**
 
 SudoSodoku is the only sudoku on the App Store that treats you like root. It is a full terminal fantasy: green phosphor on deep dark glass, mechanical-keyboard haptics, and an ELO ladder that climbs from `SCRIPT_KIDDIE` to `THE_ARCHITECT`. You are not filling in numbers — you are breaching a grid, and every victory ends the only way it should: `ACCESS GRANTED`.
 

--- a/RELEASE_NOTES_v2.0.0.md
+++ b/RELEASE_NOTES_v2.0.0.md
@@ -5,7 +5,7 @@ $ sudo solve
 > root access granted.
 ```
 
-**sudo solve — root access for logical purists.**
+**sudo solve — logic is root access.**
 
 v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a full terminal fantasy with a real competitive ladder.
 

--- a/SudoSodoku/Views/LandingView.swift
+++ b/SudoSodoku/Views/LandingView.swift
@@ -128,7 +128,7 @@ struct LandingView: View {
                 }
 
             Text("KERNEL_V\(AppConstants.marketingVersion)").font(.system(size: 14, design: .monospaced)).foregroundColor(.gray).padding(.top, 5)
-            Text("// root access for logical purists")
+            Text("// logic is root access")
                 .font(.system(size: 12, design: .monospaced))
                 .foregroundColor(.green.opacity(0.55))
                 .padding(.top, 2)


### PR DESCRIPTION
New one-line slogan distilled from the four-pillar philosophy: **`sudo solve` — logic is root access.** (standalone: **Logic is root access.**)

The only privilege escalation in this game is your reasoning — shorter than 'root access for logical purists', drops the exclusionary 'purists', ties the name, the terminal fantasy, and the no-pay-no-luck meritocracy into four words.

Applied to: README hero lockup, landing screen tagline (`// logic is root access`), RELEASE_NOTES_v2.0.0, CHANGELOG 2.0.0 identity bullet and release heading (unshipped, rides the same first archive). App Store subtitle and website copy follow from this (site handled by a separate agent brief).

Full test suite green on iPhone 17 Pro simulator.

Closes #93 · Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)