### PR TITLE
feat: in-app privacy policy access via cat /privacy on whoami

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a fu
 - Shared `SudoSodoku` scheme with test action, enabling `xcodebuild test` and Xcode Cloud test workflows
 - Product identity: slogan "sudo solve — logic is root access" (#93), four-pillar philosophy in the README, and the tagline on the landing screen
 - Public privacy policy (`PRIVACY.md`), written against App Review Guideline 5.1.1(i) and Apple's App Privacy Details guidance: all game data is local-only, the sole online service is Apple-operated Game Center, no analytics/ads/tracking; linked from the README and used as the App Store privacy policy URL (#90)
+- In-app privacy policy access: a quiet `cat /privacy` row on the whoami screen opens PRIVACY.md in the browser, satisfying Guideline 5.1.1(i)'s in-app accessibility requirement; the URL is pinned to the App Store Connect declaration by a unit test (#91)
 - Debug builds only: `$ rm -rf /user_data` factory reset in the profile (records, rating, achievements, sudoers-joke flag, and Game Center achievement progress via `resetAchievements`) for verifying first-run flows; compiled out of Release
 
 ### Changed

--- a/SudoSodoku/Utils/AppConstants.swift
+++ b/SudoSodoku/Utils/AppConstants.swift
@@ -21,6 +21,11 @@ enum AppConstants {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "2.0.0"
     }
 
+    /// Privacy policy served from the public repository; App Review
+    /// Guideline 5.1.1(i) requires it reachable from inside the app, and it
+    /// must match the URL declared in App Store Connect.
+    static let privacyPolicyURL = URL(string: "https://github.com/SudoSodokuApp/SudoSodoku/blob/main/PRIVACY.md")!
+
     static func leaderboardID(for difficulty: String) -> String {
         switch difficulty.lowercased() {
         case "easy":

--- a/SudoSodoku/Views/UserProfileView.swift
+++ b/SudoSodoku/Views/UserProfileView.swift
@@ -74,6 +74,8 @@ struct UserProfileView: View {
                         }
                     }.padding().background(Color.white.opacity(0.05)).cornerRadius(12).padding(.horizontal)
 
+                    privacyLink
+
                     #if DEBUG
                     debugWipeButton
                     #endif
@@ -83,6 +85,25 @@ struct UserProfileView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    /// Opens the privacy policy in the browser. Quiet by design: a secondary
+    /// footer action, not a green primary like `cat /leaderboard`.
+    private var privacyLink: some View {
+        Link(destination: AppConstants.privacyPolicyURL) {
+            HStack {
+                Image(systemName: "lock.shield")
+                Text("cat /privacy")
+            }
+            .font(.system(size: 14, weight: .bold, design: .monospaced))
+            .foregroundColor(.gray)
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity)
+            .background(Color.white.opacity(0.05))
+            .cornerRadius(12)
+            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.gray.opacity(0.35), lineWidth: 1))
+        }
+        .padding(.horizontal)
     }
 
     #if DEBUG

--- a/SudoSodokuTests/PrivacyPolicyLinkTests.swift
+++ b/SudoSodokuTests/PrivacyPolicyLinkTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import SudoSodoku
+
+final class PrivacyPolicyLinkTests: XCTestCase {
+
+    /// The in-app link must point at the same document declared as the
+    /// privacy policy URL in App Store Connect; a drift between the two is a
+    /// review finding waiting to happen.
+    func testPrivacyPolicyURLMatchesAppStoreConnectDeclaration() {
+        XCTAssertEqual(
+            AppConstants.privacyPolicyURL.absoluteString,
+            "https://github.com/SudoSodokuApp/SudoSodoku/blob/main/PRIVACY.md"
+        )
+    }
+
+    func testPrivacyPolicyURLUsesHTTPS() {
+        XCTAssertEqual(AppConstants.privacyPolicyURL.scheme, "https")
+    }
+}


### PR DESCRIPTION
Guideline 5.1.1(i) requires the privacy policy to be accessible **within the app**, not only in ASC metadata. This adds a quiet `cat /privacy` footer row on the whoami screen — gray/secondary styling so the green `cat /leaderboard` stays the primary action — opening PRIVACY.md via `Link`.

- URL centralized in `AppConstants.privacyPolicyURL` with a doc comment on why it must match ASC
- `PrivacyPolicyLinkTests` pins the URL to the ASC declaration and enforces https
- CHANGELOG entry under [2.0.0] (ships in the same first archive)

Full test suite green on iPhone 17 Pro simulator (including the two new tests).

Closes #91 · Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)