### PR TITLE
fix: point the privacy policy link at the product site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a fu
 - Shared `SudoSodoku` scheme with test action, enabling `xcodebuild test` and Xcode Cloud test workflows
 - Product identity: slogan "sudo solve — logic is root access" (#93), four-pillar philosophy in the README, and the tagline on the landing screen
 - Public privacy policy (`PRIVACY.md`), written against App Review Guideline 5.1.1(i) and Apple's App Privacy Details guidance: all game data is local-only, the sole online service is Apple-operated Game Center, no analytics/ads/tracking; linked from the README and used as the App Store privacy policy URL (#90)
-- In-app privacy policy access: a quiet `cat /privacy` row on the whoami screen opens PRIVACY.md in the browser, satisfying Guideline 5.1.1(i)'s in-app accessibility requirement; the URL is pinned to the App Store Connect declaration by a unit test (#91)
+- In-app privacy policy access: a quiet `cat /privacy` row on the whoami screen opens the policy on the product site (sudosodoku.kaichen.dev/privacy, rendered from PRIVACY.md), satisfying Guideline 5.1.1(i)'s in-app accessibility requirement; the URL is pinned to the App Store Connect declaration by a unit test (#91)
 - Debug builds only: `$ rm -rf /user_data` factory reset in the profile (records, rating, achievements, sudoers-joke flag, and Game Center achievement progress via `resetAchievements`) for verifying first-run flows; compiled out of Release
 
 ### Changed

--- a/SudoSodoku/Utils/AppConstants.swift
+++ b/SudoSodoku/Utils/AppConstants.swift
@@ -21,10 +21,11 @@ enum AppConstants {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "2.0.0"
     }
 
-    /// Privacy policy served from the public repository; App Review
-    /// Guideline 5.1.1(i) requires it reachable from inside the app, and it
-    /// must match the URL declared in App Store Connect.
-    static let privacyPolicyURL = URL(string: "https://github.com/SudoSodokuApp/SudoSodoku/blob/main/PRIVACY.md")!
+    /// Privacy policy on the product site (rendered from the repository's
+    /// PRIVACY.md); App Review Guideline 5.1.1(i) requires it reachable from
+    /// inside the app, and it must match the URL declared in App Store
+    /// Connect.
+    static let privacyPolicyURL = URL(string: "https://sudosodoku.kaichen.dev/privacy")!
 
     static func leaderboardID(for difficulty: String) -> String {
         switch difficulty.lowercased() {

--- a/SudoSodokuTests/PrivacyPolicyLinkTests.swift
+++ b/SudoSodokuTests/PrivacyPolicyLinkTests.swift
@@ -9,7 +9,7 @@ final class PrivacyPolicyLinkTests: XCTestCase {
     func testPrivacyPolicyURLMatchesAppStoreConnectDeclaration() {
         XCTAssertEqual(
             AppConstants.privacyPolicyURL.absoluteString,
-            "https://github.com/SudoSodokuApp/SudoSodoku/blob/main/PRIVACY.md"
+            "https://sudosodoku.kaichen.dev/privacy"
         )
     }
 


### PR DESCRIPTION
The product site is live now, so `cat /privacy` and the ASC privacy-policy declaration switch from the GitHub blob URL to **https://sudosodoku.kaichen.dev/privacy** (verified live and serving the same policy content rendered from PRIVACY.md). The URL-pinning unit test moves with it; PRIVACY.md in the repo stays the source of truth.

Full test suite green on iPhone 17 Pro simulator.

Refs #91, #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)