### PR TITLE
docs: author attribution is Kai T. Chen, linked to kaichen.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ v2.0.0 is the release where SudoSodoku becomes what it always wanted to be: a fu
 - Rating anti-smurfing: zero gain when puzzle difficulty is far below player ELO
 - Unified signing config, Swift 5.9, marketing version `1.0.0`, and `play.sh` bundle ID fallback
 - Landing page version reads from app bundle instead of hardcoded string
+- Author attribution reads Kai T. Chen throughout (LICENSE, README, source header), with links to [kaichen.dev](https://kaichen.dev) and the product site
 - Fixed swapped section bodies in DEVELOPER.md (Achievement System / iPad Support) and aligned the roadmap tiers with the phased v1.1-v1.3 plan
 
 ### Fixed

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Kai Chen
+Copyright (c) 2026 Kai T. Chen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -107,4 +107,5 @@ that version ships, with the effective date above revised.
 ## 8. Contact
 
 Questions or requests about privacy:
-open an issue at <https://github.com/SudoSodokuApp/SudoSodoku/issues>.
+open an issue at <https://github.com/SudoSodokuApp/SudoSodoku/issues>,
+or reach the developer, Kai T. Chen, via <https://kaichen.dev>.

--- a/README.md
+++ b/README.md
@@ -173,4 +173,4 @@ Your data never leaves your device: game history, rating, and achievements live 
 
 Distributed under the MIT License. See LICENSE for more information.
 
-*Created with logic and ❤️ by Kai Chen.*
+*Created with logic and ❤️ by [Kai T. Chen](https://kaichen.dev) · [sudosodoku.kaichen.dev](https://sudosodoku.kaichen.dev)*

--- a/SudoSodoku/SudoSodokuApp.swift
+++ b/SudoSodoku/SudoSodokuApp.swift
@@ -2,7 +2,7 @@
 //  SudoSodokuApp.swift
 //  SudoSodoku
 //
-//  Created by Kai Chen on 2025/12/5.
+//  Created by Kai T. Chen on 2025/12/5.
 //
 
 import SwiftUI


### PR DESCRIPTION
Every "Kai Chen" in tracked files becomes **Kai T. Chen**: LICENSE copyright, README footer, the SudoSodokuApp.swift header comment, and the PRIVACY.md contact section. Links to [kaichen.dev](https://kaichen.dev) added in the README footer (alongside the product site) and the privacy contact.

Docs/comment-only change; full test suite green.

Refs #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)