### PR TITLE
docs: add app logo to top of README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- README opens with the app logo, matching the product site
+
 ---
 
 ## [2.0.0] - 2026-07-08

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="SudoSodoku/AppIcon_V3.png" width="128" height="128" alt="SudoSodoku logo">
+</p>
+
 # **SudoSodoku**
 
 ```


### PR DESCRIPTION
Adds the app icon (`SudoSodoku/AppIcon_V3.png`) as a centered logo at the top of the README, matching the header treatment on the product site (sudosodoku.kaichen.dev). CHANGELOG `[Unreleased]` updated in the same PR per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)